### PR TITLE
image validation accuracy calculation fix

### DIFF
--- a/backend/dl/dl_trainer.py
+++ b/backend/dl/dl_trainer.py
@@ -318,7 +318,6 @@ def train_deep_image_classification(model, train_loader, test_loader, optimizer,
                     y_pred_last_epoch.append(pred.detach().numpy().squeeze())
                     labels_last_epoch.append(y.detach().numpy().squeeze())
 
-                test_correct += compute_accuracy(pred, y)
                 test_correct += (y_pred == y_true).type(torch.float).sum().item()
                 epoch_batch_loss += float(loss.detach())
 

--- a/frontend/playground-frontend/package-lock.json
+++ b/frontend/playground-frontend/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "playground-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.10.0",


### PR DESCRIPTION
Fixed bug in image validation accuracy calculation. I noticed that this bug happened because the plot made no sense. Accuracy can't exceed 1. I fixed that and you should be able to test it out. Try training MNIST in "Image Models" in the UI. 