### PR TITLE
[For Hassan Only] Removed '+' Button for 1 Layer in ML + Frontend Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deep Learning Playground
 
-Web Application where people new to Deep Learning can input a dataset and toy around with basic Pytorch modules through a drag and drop interface
+Web Application where people new to Machine Learning can input a dataset and experiment around with basic Pytorch modules through a drag and drop interface
 
 > **Deployed website:** https://datasciencegt-dlp.com/ </br>
  **GitHub repo:** https://github.com/karkir0003/Deep-Learning-Playground/ </br> **Owners:** See [CODEOWNERS](./CODEOWNERS)
@@ -10,10 +10,9 @@ Web Application where people new to Deep Learning can input a dataset and toy ar
 ## Prerequisites
 Have the following installed first:
 
-1. [NodeJS v16](https://nodejs.org/en/download/)
-2. NPM v8
-3. [Anaconda](https://www.anaconda.com/)
-4. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html). You will need to configure your AWS credentials later
+1. [NodeJS v16](https://nodejs.org/en/download/) (should come with NPM v8)
+1. [Anaconda](https://www.anaconda.com/)
+1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html). After installing, type `aws configure` in your terminal and type in the credentials given in [Secrets](https://docs.google.com/spreadsheets/d/1fRndo-7u0MXghiZoMp3uBepDBW9EghcJ9IL4yS0TdD8/edit?usp=sharing)
 
 ## Recommended
 1. [GitKraken Pro](https://help.gitkraken.com/gitkraken-client/how-to-install/)
@@ -44,7 +43,7 @@ npm run startf
 npm run startb
 ```
 
-# Backend
+# Furter Details: Backend
 
 ## Conda Env Setup
 
@@ -66,7 +65,7 @@ See [Architecture.md](./.github/Architecture.md)
 
 To see how `driver.py` is used, see [`Backend_Examples.md`](./.github/Backend_Examples.md)
 
-# Frontend
+# Furter Details: Frontend
 
 ## Startup Instructions
 

--- a/frontend/playground-frontend/src/App.css
+++ b/frontend/playground-frontend/src/App.css
@@ -152,12 +152,14 @@ input.form-control {
 /* -------------------------------------------------------------------------- */
 
 #home-page,
-#image-models {
+#image-models,
+#ml-models {
   padding: 30px 20px;
 }
 
 #home-page h2,
-#image-models h2 {
+#image-models h2,
+#ml-models h2 {
   font-weight: bold;
 }
 
@@ -177,36 +179,6 @@ input.form-control {
 .layer-box {
   width: 160px;
   height: 90px;
-}
-
-.layer-input {
-  margin-right: 20px;
-  margin-block: 10px;
-}
-
-.layer-input .layer-container {
-  height: 90px;
-  color: white;
-  font-weight: bold;
-  font-size: 1.5rem;
-  position: relative;
-  background-color: var(--tertiary);
-}
-
-.layer-input .layer-container .delete-layer {
-  position: absolute;
-  top: 5%;
-  right: 2%;
-  border: none;
-  font-size: 0.75rem;
-  background-color: transparent;
-}
-
-.layer-input .input-box {
-  width: 100%;
-  margin-top: 10px;
-  padding: 5%;
-  background-color: white;
 }
 
 .add-new-layer-bin {
@@ -235,7 +207,8 @@ input.form-control {
 }
 
 #home-page input[type="file"],
-#image-models input[type="file"] {
+#image-models input[type="file"],
+#ml-models input[type="file"] {
   display: none;
 }
 
@@ -246,6 +219,61 @@ input.form-control {
 textarea#code-snippet-text {
   width: 100%;
 }
+
+/* Added Layer */
+
+.added-layer-container {
+  margin-right: 20px;
+  margin-block: 10px;
+  width: 160px;
+}
+
+.added-layer-container .layer-container {
+  color: white;
+  font-weight: bold;
+  font-size: 1.5rem;
+  position: relative;
+  background-color: var(--tertiary);
+}
+
+.added-layer-container .layer-container .delete-layer {
+  position: absolute;
+  top: 5%;
+  right: 2%;
+  border: none;
+  font-size: 0.75rem;
+  background-color: transparent;
+}
+
+.added-layer-container .input-box {
+  width: 100%;
+  margin-top: 10px;
+  padding: 5%;
+  background-color: white;
+}
+
+.added-layer-container .layer-param-container {
+  padding-block: 7px;
+  border-bottom: 0.5px solid lightgrey;
+}
+
+.added-layer-container .layer-param-container .layer-param-input-box {
+  border-width: 0.5;
+  border-color: var(--tertiary);
+  border-radius: 0.375rem;
+  font-size: 15;
+  width: 35%;
+  padding: 5;
+}
+
+.added-layer-container .layer-param-container .param_name {
+  width: 60%;
+  margin-block: auto;
+  font-size: 15;
+  font-weight: bold;
+}
+
+/* Code Snippet */
 
 #code-snippet-div {
   position: relative;
@@ -371,11 +399,11 @@ textarea {
 }
 
 .collapsed-layer li {
-  list-style-type: '▶  ';
+  list-style-type: "▶  ";
 }
 
 .expanded-layer li {
-  list-style-type: '▼  ';
+  list-style-type: "▼  ";
 }
 
 .layer-info-button {

--- a/frontend/playground-frontend/src/components/ClassicalMLModel/ClassicalMLModel.js
+++ b/frontend/playground-frontend/src/components/ClassicalMLModel/ClassicalMLModel.js
@@ -5,7 +5,6 @@ import {
   PROBLEM_TYPES,
   ML_MODELS,
 } from "../../settings";
-import { COLORS } from "../../constants";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { FormControlLabel, Switch } from "@mui/material";
@@ -93,7 +92,7 @@ const ClassicalMLModel = () => {
     setBeginnerMode(!beginnerMode);
     setInputKey((e) => e + 1);
   };
-  //whats this
+
   return (
     <div id="ml-models">
       <DndProvider backend={HTML5Backend}>
@@ -128,21 +127,9 @@ const ClassicalMLModel = () => {
                 currentLayers.splice(i, 1);
                 setAddedLayers(currentLayers);
               }}
-              style={{
-                input_box: {
-                  margin: 7.5,
-                  backgroundColor: "white",
-                  width: 170,
-                  paddingInline: 5,
-                },
-                layer_box: {
-                  width: 150,
-                  backgroundColor: COLORS.layer,
-                },
-              }}
             />
           ))}
-          <AddNewLayer />
+          {addedLayers.length >= 1 ? null : <AddNewLayer />}
           <TrainButton
             {...input_responses}
             setDLPBackendResponse={setDLPBackendResponse}

--- a/frontend/playground-frontend/src/components/Home/AddedLayer.js
+++ b/frontend/playground-frontend/src/components/Home/AddedLayer.js
@@ -1,14 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { COLORS, GENERAL_STYLES, LAYOUT } from "../../constants";
 
 const _InputOutputPromptResponse = (props) => {
   const { param_key, allParamInputs, setAddedLayers, thisLayerIndex } = props;
   const { parameter_name, value, min, max } = allParamInputs[param_key];
 
   return (
-    <div style={{ ...LAYOUT.row, alignItems: "center" }}>
-      <p style={styles.input_prompt}>{`${parameter_name}:`}</p>&nbsp;
+    <div className="layer-param-container d-flex justify-content-between align-items-center">
+      <p className="param_name">{parameter_name}</p>
       <input
         type={parameter_name === "(H, W)" ? "" : "number"}
         min={min}
@@ -23,7 +22,7 @@ const _InputOutputPromptResponse = (props) => {
             return copyCurrent;
           })
         }
-        style={styles.input_text}
+        className="layer-param-input-box"
       />
     </div>
   );
@@ -49,7 +48,7 @@ const AddedLayer = (props) => {
   });
 
   return (
-    <div className="layer-input">
+    <div className="added-layer-container">
       <div className="layer-box layer-container text-center d-flex justify-content-center align-items-center">
         <button className="delete-layer" onClick={onDelete}>
           ❌
@@ -81,23 +80,3 @@ AddedLayer.propTypes = {
 };
 
 export default AddedLayer;
-
-let styles = {
-  layer_box: {
-    backgroundColor: COLORS.layer,
-    width: 130,
-  },
-  text: { ...GENERAL_STYLES.p, color: "white", fontSize: 25 },
-  input_prompt: {
-    fontSize: 15,
-    fontWeight: "bold",
-  },
-  input_text: {
-    borderWidth: 0.5,
-    borderColor: COLORS.layer,
-    borderRadius: "0.375rem",
-    fontSize: 15,
-    maxWidth: "45%",
-    padding: 5,
-  },
-};

--- a/frontend/playground-frontend/src/components/Home/LayerChoice.js
+++ b/frontend/playground-frontend/src/components/Home/LayerChoice.js
@@ -45,7 +45,7 @@ const LayerChoice = (props) => {
       ref2={drag}
       style={{ opacity }}
       dataTestid="box"
-      className="d-flex justify-content-center align-items-center layer-box layer-choice"
+      className="d-flex justify-content-center align-items-center layer-box layer-choice text-center"
     >
       <div>
         <HtmlTooltip

--- a/frontend/playground-frontend/src/components/Home/Results.js
+++ b/frontend/playground-frontend/src/components/Home/Results.js
@@ -279,6 +279,7 @@ Results.propTypes = {
     success: PropTypes.bool.isRequired,
   }),
   problemType: PropTypes.objectOf(PropTypes.string).isRequired,
+  choice: PropTypes.string,
 };
 
 export default Results;

--- a/frontend/playground-frontend/src/settings.js
+++ b/frontend/playground-frontend/src/settings.js
@@ -416,7 +416,7 @@ export const IMAGE_LAYERS = [
     ),
   },
   {
-    display_name: "AdaptAvgPool2d",
+    display_name: "AdaptAvg Pool2d",
     object_name: "nn.AdaptiveAvgPool2d",
     parameters: {
       output_size: {


### PR DESCRIPTION
A PR To Resolve #454 and Frontend Improvements for Hassan Naveed

We resolve #454 by removing the + button when one layer is added; the + layer is available when the present layer is deleted. 
![image](https://user-images.githubusercontent.com/40067313/200098250-0a69c1ba-6b61-4c3d-b4e4-990d7b067425.png)
![image](https://user-images.githubusercontent.com/40067313/200098373-2b8a137f-9504-44cb-90b8-a829fa26c3ac.png)


We also made improvements to the frontend, namely:
- README updates to clarify AWS configure steps
- Added page padding to trad-ml already present in other training pages
- Restored styles lost in duplication of an available training page into trad-ml page
- Improved added layer parameter input styling, including adding a gray line separator
- Multiple inline CSS removals to migrate to external CSS styling
