### PR TITLE
Injecting REACT_APP_MODE=prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,7 @@ COPY . .
 
 RUN npm run secrets:deploy
 
-RUN npm run prod:variable
-
-RUN npm run build
+RUN npm run build:prod
 
 CMD python -m backend.driver
 

--- a/frontend/playground-frontend/package-lock.json
+++ b/frontend/playground-frontend/package-lock.json
@@ -18,7 +18,6 @@
         "@uiw/react-codemirror": "^4.12.3",
         "axios": "^0.27.2",
         "bootstrap": "^5.2.1",
-        "dotenv-cli": "^7.0.0",
         "firebase": "^9.9.3",
         "http-proxy-middleware": "^2.0.6",
         "local-storage-fallback": "^4.1.2",
@@ -8274,36 +8273,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dotenv-cli": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.0.0.tgz",
-      "integrity": "sha512-XfMzVdpdDTRnlcgvFLg3lSyiLXqFxS4tH7RbK5IxkC4XIUuxPyrGoDufkfLjy/dA28EILzEu+mros6h8aQmyGg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "dotenv": "^16.0.0",
-        "dotenv-expand": "^10.0.0",
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "dotenv": "cli.js"
-      }
-    },
-    "node_modules/dotenv-cli/node_modules/dotenv-expand": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -26956,29 +26925,6 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
-    },
-    "dotenv-cli": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.0.0.tgz",
-      "integrity": "sha512-XfMzVdpdDTRnlcgvFLg3lSyiLXqFxS4tH7RbK5IxkC4XIUuxPyrGoDufkfLjy/dA28EILzEu+mros6h8aQmyGg==",
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "dotenv": "^16.0.0",
-        "dotenv-expand": "^10.0.0",
-        "minimist": "^1.2.6"
-      },
-      "dependencies": {
-        "dotenv-expand": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-          "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
-        }
       }
     },
     "dotenv-expand": {

--- a/frontend/playground-frontend/package.json
+++ b/frontend/playground-frontend/package.json
@@ -13,7 +13,6 @@
     "@uiw/react-codemirror": "^4.12.3",
     "axios": "^0.27.2",
     "bootstrap": "^5.2.1",
-    "dotenv-cli": "^7.0.0",
     "firebase": "^9.9.3",
     "http-proxy-middleware": "^2.0.6",
     "local-storage-fallback": "^4.1.2",

--- a/frontend/playground-frontend/src/components/helper_functions/TalkWithBackend.js
+++ b/frontend/playground-frontend/src/components/helper_functions/TalkWithBackend.js
@@ -57,7 +57,7 @@ const routeDict = {
 };
 
 async function train_and_output(choice, choiceDict) {
-  if (process.env.MODE === "prod") {
+  if (process.env.REACT_APP_MODE === "prod") {
     //TODO: submit request to sqs. return success or fail message!
     const trainResult = await sendToBackend(routeDict[choice], choiceDict);
     return trainResult;

--- a/package.json
+++ b/package.json
@@ -4,15 +4,14 @@
   "description": "Web Application where people new to Deep Learning can input a dataset and toy around with basic Pytorch modules through a drag and drop interface.",
   "main": "index.js",
   "scripts": {
-    "build": "cd frontend/playground-frontend && npm install && npm run build",
+    "build:prod": "cd frontend/playground-frontend && npm install && REACT_APP_MODE=prod npm run build",
     "installf": "cd frontend/playground-frontend && npm install",
     "installb": "conda --version && cd conda && conda env create -f environment.yml & conda env update -f environment.yml",
     "startf": "cd frontend/playground-frontend && npm start",
     "startb": "conda activate dlplayground && python -m backend.driver",
     "secrets": "conda activate dlplayground && python -m backend.aws_helpers.aws_secrets_utils.build_env",
     "secrets:deploy": "python -m backend.aws_helpers.aws_secrets_utils.build_env",
-    "docker:build": "docker build -t dlp .",
-    "prod:variable": "npm install -g dotenv-cli && cd frontend/playground-frontend && dotenv set MODE prod"
+    "docker:build": "docker build -t dlp ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# A PR to have the frontend environment be `prod` in prod

By default, starting the frontend using `npm run startf` shall not declare a mode, which in absence is defined as a `test` environment. In production, we want the mode (`process.env.REACT_APP_MODE`) = `prod`.

Before, we recommended using dotenv-cli but that seemed to only work on Windows which is not our prod OS: Linux. A better simpler solution is to inject it while starting the app i.e. `REACT_APP_MODE=dev npm start`, a command which works in Unix terminals. The package is no longer required and thus uninstalled