### PR TITLE
GitGuardian pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.14.2
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [commit]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Have the following installed first:
 | Running the Frontend                                     | `npm run startf`       |
 | Running the Backend                         | `npm run startb`   |
 
-
+# Development Practices
+## GitGuardian Pre-commit Check
+To protect our secrets, we use the GitGuardian ggshield pre-commit check to ensure no keys are being committed. After installing the backend, every day or so, login to GitGuardian to activate the pre-commit hook using `ggshield auth login`.
 
 # Further Details: Backend
 
@@ -62,7 +64,6 @@ To see how `driver.py` is used, see [`Backend_Examples.md`](./.github/Backend_Ex
 
     ```
     cd frontend\playground-frontend
-    dotenv set MODE=dev
     npm install
     npm start
     ```

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -29,6 +29,8 @@ dependencies:
   - eventlet
   - python-dotenv
   - transformers
+  - ggshield
+  - pre-commit
   - pip:
       - torchvision
       - timm

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:prod": "cd frontend/playground-frontend && npm install && REACT_APP_MODE=prod npm run build",
     "installf": "cd frontend/playground-frontend && npm install",
-    "installb": "conda --version && cd conda && conda env create -f environment.yml & conda env update -f environment.yml",
+    "installb": "conda --version && cd conda && conda env create -f environment.yml && pre-commit install",
     "startf": "cd frontend/playground-frontend && npm start",
     "startb": "conda activate dlplayground && python -m backend.driver",
     "secrets": "conda activate dlplayground && python -m backend.aws_helpers.aws_secrets_utils.build_env",


### PR DESCRIPTION
To protect against leaking secret keys before committing, we ask that developers install ggshield and to login using `ggshield auth login` as necessary to have the service check for secrets before commiting