### PR TITLE
Dockerfile fixes

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -90,7 +90,7 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg AWS_REGION=${{ secrets.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg TARGETARCH="x86" --build-arg AWS_REGION=${{ secrets.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/training-container.yml
+++ b/.github/workflows/training-container.yml
@@ -77,7 +77,7 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -f TrainingContainer.Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --platform linux/arm64 --build-arg AWS_REGION=${{ env.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
+        docker build -f TrainingContainer.Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg AWS_REGION=${{ env.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/training-container.yml
+++ b/.github/workflows/training-container.yml
@@ -77,7 +77,7 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -f TrainingContainer.Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg AWS_REGION=${{ env.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
+        docker build -f TrainingContainer.Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --platform linux/arm64 --build-arg AWS_REGION=${{ env.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/training-container.yml
+++ b/.github/workflows/training-container.yml
@@ -77,7 +77,7 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -f TrainingContainer.Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg AWS_REGION=${{ env.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
+        docker build -f TrainingContainer.Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg TARGETARCH="x86" --build-arg AWS_REGION=${{ env.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ EXPOSE 8000
 
 WORKDIR /
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ ARG AWS_REGION
 ARG AWS_DEPLOY_SECRET_ACCESS_KEY
 ARG AWS_DEPLOY_ACCESS_KEY_ID
 
+RUN echo "aws cli installed. now seeing path"
+RUN echo $PATH
+RUN echo "path variable shown"
 RUN aws configure set region $AWS_REGION
 RUN aws configure set aws_access_key_id $AWS_DEPLOY_ACCESS_KEY_ID
 RUN aws configure set aws_secret_access_key $AWS_DEPLOY_SECRET_ACCESS_KEY

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ ARG AWS_REGION
 ARG AWS_DEPLOY_SECRET_ACCESS_KEY
 ARG AWS_DEPLOY_ACCESS_KEY_ID
 
-RUN echo "aws cli installed. now seeing path"
-RUN echo $PATH
-RUN echo "path variable shown"
 RUN aws configure set region $AWS_REGION
 RUN aws configure set aws_access_key_id $AWS_DEPLOY_ACCESS_KEY_ID
 RUN aws configure set aws_secret_access_key $AWS_DEPLOY_SECRET_ACCESS_KEY

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,14 @@ FROM nikolaik/python-nodejs:latest
 EXPOSE 8000
 
 WORKDIR /
+ARG TARGETARCH
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN if [ "${TARGETARCH}" = "arm64" ] ; then \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" ; \
+    else \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" ; \
+    fi
+
 RUN unzip awscliv2.zip
 RUN ./aws/install
 

--- a/TrainingContainer.Dockerfile
+++ b/TrainingContainer.Dockerfile
@@ -10,6 +10,7 @@ COPY . .
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
+RUN chmod +rwx /usr/local/bin/aws
 
 ARG AWS_REGION
 ARG AWS_DEPLOY_ACCESS_KEY_ID

--- a/TrainingContainer.Dockerfile
+++ b/TrainingContainer.Dockerfile
@@ -16,8 +16,6 @@ ARG AWS_REGION
 ARG AWS_DEPLOY_ACCESS_KEY_ID
 ARG AWS_DEPLOY_SECRET_ACCESS_KEY
 
-RUN which aws
-
 RUN aws configure set region $AWS_REGION
 RUN aws configure set aws_access_key_id $AWS_DEPLOY_ACCESS_KEY_ID
 RUN aws configure set aws_secret_access_key $AWS_DEPLOY_SECRET_ACCESS_KEY

--- a/TrainingContainer.Dockerfile
+++ b/TrainingContainer.Dockerfile
@@ -6,8 +6,14 @@ COPY requirements.txt .
 RUN apt-get update -y && apt-get install -y gcc && apt-get install -y curl && apt-get install -y unzip
 RUN pip install -r requirements.txt
 COPY . .
+ARG TARGETARCH
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN if [ "${TARGETARCH}" = "arm64" ] ; then \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" ; \
+    else \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" ; \
+    fi
+
 RUN unzip awscliv2.zip
 RUN ./aws/install
 

--- a/TrainingContainer.Dockerfile
+++ b/TrainingContainer.Dockerfile
@@ -15,6 +15,9 @@ ARG AWS_REGION
 ARG AWS_DEPLOY_ACCESS_KEY_ID
 ARG AWS_DEPLOY_SECRET_ACCESS_KEY
 
+RUN echo "showing aws install path"
+RUN echo $PATH 
+RUN echo "above is aws path"
 RUN aws configure set region $AWS_REGION
 RUN aws configure set aws_access_key_id $AWS_DEPLOY_ACCESS_KEY_ID
 RUN aws configure set aws_secret_access_key $AWS_DEPLOY_SECRET_ACCESS_KEY

--- a/TrainingContainer.Dockerfile
+++ b/TrainingContainer.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y && apt-get install -y gcc && apt-get install -y curl && ap
 RUN pip install -r requirements.txt
 COPY . .
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN chmod +rwx /usr/local/bin/aws

--- a/TrainingContainer.Dockerfile
+++ b/TrainingContainer.Dockerfile
@@ -15,9 +15,7 @@ ARG AWS_REGION
 ARG AWS_DEPLOY_ACCESS_KEY_ID
 ARG AWS_DEPLOY_SECRET_ACCESS_KEY
 
-RUN echo "showing aws install path"
-RUN echo $PATH 
-RUN echo "above is aws path"
+RUN /usr/local/bin/aws --version
 RUN aws configure set region $AWS_REGION
 RUN aws configure set aws_access_key_id $AWS_DEPLOY_ACCESS_KEY_ID
 RUN aws configure set aws_secret_access_key $AWS_DEPLOY_SECRET_ACCESS_KEY

--- a/TrainingContainer.Dockerfile
+++ b/TrainingContainer.Dockerfile
@@ -10,7 +10,6 @@ COPY . .
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
-RUN chmod +rwx /usr/local/bin/aws
 
 ARG AWS_REGION
 ARG AWS_DEPLOY_ACCESS_KEY_ID

--- a/TrainingContainer.Dockerfile
+++ b/TrainingContainer.Dockerfile
@@ -15,7 +15,8 @@ ARG AWS_REGION
 ARG AWS_DEPLOY_ACCESS_KEY_ID
 ARG AWS_DEPLOY_SECRET_ACCESS_KEY
 
-RUN /usr/local/bin/aws --version
+RUN which aws
+
 RUN aws configure set region $AWS_REGION
 RUN aws configure set aws_access_key_id $AWS_DEPLOY_ACCESS_KEY_ID
 RUN aws configure set aws_secret_access_key $AWS_DEPLOY_SECRET_ACCESS_KEY


### PR DESCRIPTION
# Dockerfile Fixes for deploying to prod

**What user problem are we solving?**
The `TrainingContainer.Dockerfile` builds locally. However, when running on Github action, the ECS Training container deployment flow fails because the dockerfile doesn't build due to the fact that github action is an ubuntu environment and it needs the x86-64 architecture of AWS CLI. However, some of the devs use mac, so it would be annoying for the developers to have to change one url in dockerfile to test if stuff works correctly.

**What solution does this PR provide?**
Safety check for dockerfile to work regardless of x86 vs. arm64 architecture. Simply pass in a build arg for target arch like `--build-arg TARGETARCH="arm64"` in the docker build when testing locally if prod version works

**Testing Methodology**
Run in Github Action and used LLMs to debug
**Any other considerations**
Make sure we update docs to reflect this