### PR TITLE
nodejs github action version bump

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/frontend/playground-frontend/Hello.js
+++ b/frontend/playground-frontend/Hello.js
@@ -1,0 +1,1 @@
+console.log('Hello world')

--- a/frontend/playground-frontend/Hello.js
+++ b/frontend/playground-frontend/Hello.js
@@ -1,1 +1,0 @@
-console.log("Hello world");

--- a/frontend/playground-frontend/Hello.js
+++ b/frontend/playground-frontend/Hello.js
@@ -1,1 +1,1 @@
-console.log('Hello world')
+console.log("Hello world");


### PR DESCRIPTION
# Node JS Github Action Version Bump

**What user problem are we solving?**
Team shifted to using Node v18 instead of v16, so we are updating our Github Action `nodejs.yml` workflow to run frontend build check on node version 18 to mimic our team's setup.
**What solution does this PR provide?**
Simple version bump in github action
**Testing Methodology**
Verify in Github Action with a tiny frontend change

**Any other considerations**
Make sure the updated version of `nodejs.yml` works before merging