### PR TITLE
Health Check endpoint added

### DIFF
--- a/frontend/playground-frontend/src/App.js
+++ b/frontend/playground-frontend/src/App.js
@@ -46,7 +46,7 @@ function App() {
               }
             />
             <Route path="/login" element={<Login />} />
-            <Route path="/heath" element={<Health />} />
+            <Route path="/health" element={<Health />} />
             <Route path="/train" element={verifyLogin(<Home />)} />
             <Route path="/img-models" element={verifyLogin(<ImageModels />)} />
             <Route

--- a/frontend/playground-frontend/src/App.js
+++ b/frontend/playground-frontend/src/App.js
@@ -15,6 +15,7 @@ import {
   Forgot,
   AccountSettings,
   ObjectDetection,
+  Health,
 } from "./components";
 import Home from "./Home";
 import { ToastContainer } from "react-toastify";
@@ -45,6 +46,7 @@ function App() {
               }
             />
             <Route path="/login" element={<Login />} />
+            <Route path="/heath" element={<Health />} />
             <Route path="/train" element={verifyLogin(<Home />)} />
             <Route path="/img-models" element={verifyLogin(<ImageModels />)} />
             <Route

--- a/frontend/playground-frontend/src/components/Health/Health.js
+++ b/frontend/playground-frontend/src/components/Health/Health.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+const Health = () => {
+    return (
+        <h3>Hey There!!! The App is Healthy</h3>
+    );
+};
+
+export default Health;

--- a/frontend/playground-frontend/src/components/Health/Health.js
+++ b/frontend/playground-frontend/src/components/Health/Health.js
@@ -1,9 +1,7 @@
 import React from "react";
 
 const Health = () => {
-    return (
-        <h3>Hey There!!! The App is Healthy</h3>
-    );
+  return <h3>Hey There!!! The App is Healthy</h3>;
 };
 
 export default Health;

--- a/frontend/playground-frontend/src/components/index.js
+++ b/frontend/playground-frontend/src/components/index.js
@@ -43,6 +43,9 @@ export { default as Feedback } from "./Feedback/Feedback";
 export { default as LearnMod } from "./LearnMod/LearnMod";
 export { default as LearnContent } from "./LearnMod/LearnContent";
 
+//Health
+export { default as Health} from "./Health/Health";
+
 // Navbar
 export { default as NavbarMain } from "./Navbar/NavbarMain";
 

--- a/frontend/playground-frontend/src/components/index.js
+++ b/frontend/playground-frontend/src/components/index.js
@@ -44,7 +44,7 @@ export { default as LearnMod } from "./LearnMod/LearnMod";
 export { default as LearnContent } from "./LearnMod/LearnContent";
 
 //Health
-export { default as Health} from "./Health/Health";
+export { default as Health } from "./Health/Health";
 
 // Navbar
 export { default as NavbarMain } from "./Navbar/NavbarMain";


### PR DESCRIPTION
# Health Check Endpoint Added

**What user problem are we solving?**
Adding a dummy route called /health in order to see if frontend is alive. Our load balancer in AWS routes internet traffic to a target group and before we can get our updated frontend up and running on AWS, we need to make sure that the target group is healthy. Target group simply makes a request to the route you provide and if code 200 is returned, target group is marked as healthy.
**What solution does this PR provide?**
Add a dummy route called /health for the target group in AWS to make a GET request to.
**Testing Methodology**
Verified that I can access the /health route within localhost. Need to verify that this works on AWS
**Any other considerations**
Make sure that we can revert back to a working version in AWS if the target group health check doesn't work