### PR TITLE
middleware fix to make /test exempt from authentication

### DIFF
--- a/backend/driver.py
+++ b/backend/driver.py
@@ -40,7 +40,7 @@ app = Flask(
 )
 CORS(app)
 
-app.wsgi_app = middleware(app.wsgi_app)
+app.wsgi_app = middleware(app.wsgi_app, exempt_paths=['/test'])
 
 @app.route("/", defaults={"path": ""})
 @app.route("/<path:path>")

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -30,11 +30,15 @@ class middleware:
         return url_map
     
     def __call__(self, environ, start_response):
-        request = Request(environ)
-        rule = self.url_map.bind_to_environ(environ).match()
-        endpoint = rule[0]
-        if (endpoint == 'test'):
-            return self.app(environ, start_response) #publicly accessible route
+        try:
+            request = Request(environ)
+            rule = self.url_map.bind_to_environ(environ).match()
+            endpoint = rule[0]
+            print(f"endpoint: {endpoint}")
+            if (endpoint is not None):
+                return self.app(environ, start_response) #exempt paths are publicly accessible
+        except Exception as e:
+            return send_error(environ, start_response)
         
         if (
             "Authorization" in request.headers

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -34,7 +34,6 @@ class middleware:
             request = Request(environ)
             rule = self.url_map.bind_to_environ(environ).match()
             endpoint = rule[0]
-            print(f"endpoint: {endpoint}")
             if (endpoint is not None):
                 return self.app(environ, start_response) #exempt paths are publicly accessible
         except Exception as e:

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -1,8 +1,12 @@
 from werkzeug.wrappers import Request, Response, ResponseStream
-
+from werkzeug.routing import Map, Rule
 from backend.firebase_helpers.authenticate import authenticate
 import json
 
+#Make sure that this is unique!
+url_map = Map([
+    Rule('/test', endpoint='test'),
+])
 
 def send_error(environ, start_response):
     response = Response(
@@ -14,11 +18,24 @@ def send_error(environ, start_response):
 
 
 class middleware:
-    def __init__(self, app):
+    def __init__(self, app, exempt_paths=None):
         self.app = app
-
+        self.exempt_paths=exempt_paths
+        self.url_map = self.build_url_map(exempt_paths)
+        
+    def build_url_map(self, exempt_paths):
+        url_map = Map([])
+        for path in exempt_paths:
+            url_map.add(Rule(path, endpoint=path[1:])) #strip off the "/"
+        return url_map
+    
     def __call__(self, environ, start_response):
         request = Request(environ)
+        rule = self.url_map.bind_to_environ(environ).match()
+        endpoint = rule[0]
+        if (endpoint == 'test'):
+            return self.app(environ, start_response) #publicly accessible route
+        
         if (
             "Authorization" in request.headers
             and "bearer " in request.headers["Authorization"]


### PR DESCRIPTION
# Modify middleware wsgi_app script to add exempt paths

**What user problem are we solving?**
When pinging any endpoint (like `GET localhost:8000/test`) in our backend, we are required to be authenticated user (ie: headers needs to be passed in the payload). However, AWS health checks require that we have >=1 lightweight endpoint be publicly accessible. When pinging `GET localhost:8000/test`, I get a 401 locally. From debugging, I found out that when the flask app is a `wsgi_app`, our middleware script forces every single request to be authenticated. 
**What solution does this PR provide?**
Add functionality for us to add "exempt_routes" from the authentication request
**Testing Methodology**
Ping an exempt endpoint at `localhost:8000/<route>` and see if I don't get a 401 error. Ping an endpoint that's not exempt and see if I get a 401 error

**Any other considerations**
Hope it works on AWS ECS deployment 🙏 