### PR TITLE
Resolved feature target disparity

### DIFF
--- a/frontend/playground-frontend/src/features/Train/features/Tabular/components/TabularParametersStep.tsx
+++ b/frontend/playground-frontend/src/features/Train/features/Tabular/components/TabularParametersStep.tsx
@@ -75,8 +75,10 @@ const TabularParametersStep = ({
     : { data: undefined };
   const {
     handleSubmit,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, dirtyFields },
     control,
+    getValues,
+    watch
   } = useForm<ParameterData>({
     defaultValues: {
       targetCol:
@@ -109,10 +111,14 @@ const TabularParametersStep = ({
       ],
     },
   });
+
   useEffect(() => {
     setIsModified(isDirty);
   }, [isDirty]);
   if (!trainspace || !data) return <></>;
+  const targetCol = watch("targetCol");
+  const features = watch("features")
+
   return (
     <Stack spacing={3}>
       <Controller
@@ -136,7 +142,7 @@ const TabularParametersStep = ({
                 error={errors.targetCol ? true : false}
               />
             )}
-            options={data}
+            options={data.filter(col => !features.includes(col))}
           />
         )}
       />
@@ -162,7 +168,8 @@ const TabularParametersStep = ({
                 error={errors.features ? true : false}
               />
             )}
-            options={data}
+            
+            options={data.filter(col => col!== targetCol)}
           />
         )}
       />

--- a/frontend/playground-frontend/src/features/Train/features/Tabular/components/TabularParametersStep.tsx
+++ b/frontend/playground-frontend/src/features/Train/features/Tabular/components/TabularParametersStep.tsx
@@ -75,9 +75,8 @@ const TabularParametersStep = ({
     : { data: undefined };
   const {
     handleSubmit,
-    formState: { errors, isDirty, dirtyFields },
+    formState: { errors, isDirty },
     control,
-    getValues,
     watch
   } = useForm<ParameterData>({
     defaultValues: {
@@ -117,7 +116,7 @@ const TabularParametersStep = ({
   }, [isDirty]);
   if (!trainspace || !data) return <></>;
   const targetCol = watch("targetCol");
-  const features = watch("features")
+  const features = watch("features");
 
   return (
     <Stack spacing={3}>


### PR DESCRIPTION
Added logic to ensure that upon selecting a targetCol, the same field cannot be selected as a feature and vice versa. Attached a screenshot below.
![image](https://github.com/DSGT-DLP/Deep-Learning-Playground/assets/41639552/2533760b-2ce1-4609-9ea4-2470cc5ed865)

Vice versa case (selected sepal length and sepal width)
![image](https://github.com/DSGT-DLP/Deep-Learning-Playground/assets/41639552/24363e66-4244-46c7-9ed5-dce37301d2fb)
