### PR TITLE
Fix Sign In Bug

### DIFF
--- a/frontend/playground-frontend/src/common/redux/userLogin.ts
+++ b/frontend/playground-frontend/src/common/redux/userLogin.ts
@@ -388,17 +388,29 @@ export const currentUserSlice = createSlice({
         state.user = payload;
       }
     );
+    builder.addCase(registerViaEmailAndPassword.rejected, (state) => {
+      state.user = undefined;
+    });
     builder.addCase(signOutUser.fulfilled, (state) => {
       state.user = undefined;
     });
     builder.addCase(signInViaEmailAndPassword.pending, (state) => {
       state.user = "pending";
     });
+    builder.addCase(signInViaEmailAndPassword.rejected, (state) => {
+      state.user = undefined;
+    });
     builder.addCase(signInViaGoogleRedirect.pending, (state) => {
       state.user = "pending";
     });
+    builder.addCase(signInViaGoogleRedirect.rejected, (state) => {
+      state.user = undefined;
+    });
     builder.addCase(signInViaGithubRedirect.pending, (state) => {
       state.user = "pending";
+    });
+    builder.addCase(signInViaGithubRedirect.rejected, (state) => {
+      state.user = undefined;
     });
     builder.addCase(fetchUserProgressData.pending, (state) => {
       state.userProgressData = undefined;

--- a/frontend/playground-frontend/src/pages/train/[train_space_id].tsx
+++ b/frontend/playground-frontend/src/pages/train/[train_space_id].tsx
@@ -1,12 +1,14 @@
 import Footer from "@/common/components/Footer";
 import NavbarMain from "@/common/components/NavBarMain";
+import { useAppSelector } from "@/common/redux/hooks";
+import { isSignedIn } from "@/common/redux/userLogin";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { Data, XAxisName, YAxisName } from "plotly.js";
-import React from "react";
+import React, { useEffect } from "react";
 const Plot = dynamic(() => import("react-plotly.js"), { ssr: false });
 
 const TrainSpace = () => {
@@ -91,6 +93,16 @@ const TrainSpace = () => {
     },
     status: 200,
   };
+  const user = useAppSelector((state) => state.currentUser.user);
+  const router = useRouter();
+  useEffect(() => {
+    if (router.isReady && !user) {
+      router.replace({ pathname: "/login" });
+    }
+  }, [user, router.isReady]);
+  if (!isSignedIn(user)) {
+    return <></>;
+  }
   return (
     <div style={{ height: "100vh" }}>
       <NavbarMain />


### PR DESCRIPTION
# Fix Sign In Bug

**What user problem are we solving?**
Invalid user sign in causes blank screen
**What solution does this PR provide?**
The reason why this happened is because the user is set to "pending" whenever any sign in method is initiated, and right now all pages are programmed to show a blank screen whenever the user is in the "pending" state (the user redux store is literally set to the string "pending"). Because all signing in is handled by async thunks, extrareducers are used to translate the state of async thunk actions (pending, fulfilled, rejected) into user states (undefined, "pending", {object containing user data}). The rejected case of the async thunks wasn't handled properly by the extrareducers, causing the blank screen to appear indefinitely on failed thunk actions. This PR implements that, which should hopefully solve this issue. A blank screen will still flash on signing in, however, since that's just a placeholder for some sort of loading screen that we can implement later on.
  
**Testing Methodology**
UI correctly handles invalid sign in inputs

**Any other considerations**