### PR TITLE
Open API Schema - for Redocly

### DIFF
--- a/.github/workflows/open-api-validation.yml
+++ b/.github/workflows/open-api-validation.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Check file extensions
         run: |
           shopt -s globstar
-          for file in backend/openapi/**/*.yaml; do
-            if [[ ! "$file" =~ \.yml$ ]]; then
+          for file in openapi/*.yaml; do
+            if [[ ! "$file" =~ \.yaml$ ]]; then
               echo "Error: $file does not have the .yml extension"
               exit 1
             fi

--- a/.github/workflows/open-api-validation.yml
+++ b/.github/workflows/open-api-validation.yml
@@ -1,0 +1,39 @@
+name: OpenAPI Schema Validation
+
+on:
+  push:
+    paths:
+      - "openapi/**"
+  pull_request:
+    paths:
+      - "openapi/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check file extensions
+        run: |
+          shopt -s globstar
+          for file in backend/openapi/**/*.yaml; do
+            if [[ ! "$file" =~ \.openapi\.yaml$ ]]; then
+              echo "Error: $file does not have the .openapi.yaml extension"
+              exit 1
+            fi
+          done
+      - name: Validate OpenAPI files
+        run: |
+          yarn add swagger-cli
+          for file in backend/openapi/*.yaml
+          do
+            echo "Validating $file"
+            yarn swagger-cli validate $file --no-color || exit 1
+          done

--- a/.github/workflows/open-api-validation.yml
+++ b/.github/workflows/open-api-validation.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Validate OpenAPI files
         run: |
           yarn add swagger-cli
-          for file in backend/openapi/*.yaml
+          for file in openapi/*.yaml
           do
             echo "Validating $file"
             yarn swagger-cli validate $file --no-color || exit 1

--- a/.github/workflows/open-api-validation.yml
+++ b/.github/workflows/open-api-validation.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           shopt -s globstar
           for file in backend/openapi/**/*.yaml; do
-            if [[ ! "$file" =~ \.openapi\.yaml$ ]]; then
-              echo "Error: $file does not have the .openapi.yaml extension"
+            if [[ ! "$file" =~ \.yml$ ]]; then
+              echo "Error: $file does not have the .yml extension"
               exit 1
             fi
           done

--- a/openapi/dataset_endpoints.yaml
+++ b/openapi/dataset_endpoints.yaml
@@ -1,0 +1,98 @@
+openapi: "3.0.0"
+info:
+  title: DLP API
+  description: API endpoints for the Deep Learning Playground Project
+  version: "1.0.0"
+paths:
+  /api/dataset/defaultDataset:
+    post:
+      description: Endpoint to get user selected default dataset for training
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              required:
+                - using_default_dataset
+              properties:
+                using_default_dataset:
+                  type: string
+                  description: dataset selected for training
+              example:
+                using_default_dataset: "IRIS"
+        required: true
+      responses:
+        "200":
+          description: Dataset selected successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  columns:
+                    type: array
+                    example: [col1, col2, col3]
+        "400":
+          description: Dataset wasn't selected properly. This is usually something wrong with your code
+        "401":
+          description: User is not authenticated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "User is not authenticated"
+  /api/dataset/getColumnsFromDatasetFile:
+    post: 
+      description: 'API Endpoint to retrieve columns from a user uploaded dataset file (eg: column names for a CSV file)'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              required:
+                - uid
+                - data_source
+                - name
+              properties:
+                uid:
+                  type: string 
+                  description: User Id
+                data_source: 
+                  type: string 
+                  description: 'What type of training was the user running (eg: TABULAR, PRETRAINED, OBJECT_DETECTION, IMAGE, etc)'
+                name: 
+                  type: string 
+                  description: Name of dataset file 
+              example: 
+                uid: '1234'
+                data_source: 'TABULAR'
+                name: 'data.csv'
+        required: true 
+      responses:
+        "200":
+          description: Columns Fetched Successfully 
+          content:
+            application/json:
+              schema: 
+                type: object 
+                properties:
+                  columns:
+                    type: array
+                    example: [col1, col2, col3]
+        "400":
+          description: Dataset columns weren't selected properly. This is usually something wrong with your code
+        "401":
+          description: User is not authenticated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "User is not authenticated"
+
+              

--- a/openapi/s3_endpoints.yaml
+++ b/openapi/s3_endpoints.yaml
@@ -1,0 +1,137 @@
+openapi: "3.0.0"
+info:
+  title: DLP API
+  description: API endpoints for the Deep Learning Playground Project
+  version: "1.0.0"
+paths:
+  /api/s3/getSignedUploadUrl:
+    post:
+      description: Endpoint to upload files to S3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - version
+                - filename
+                - file
+              properties:
+                version:
+                  type: integer
+                  description: The file version
+                filename:
+                  type: string
+                  description: The name of the file
+                file:
+                  type: object
+                  description: the file
+              example:
+                version: 2
+                filename: "file"
+                file: { "col1": [val1, val2], "col2": [val3, val4] }
+        required: true
+      responses:
+        "200":
+          description: Data uploaded successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Upload successful"
+        "400":
+          description: Upload didn't go through successfully. This is usually something wrong with your code
+        "401":
+          description: User is not authenticated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "User is not authenticated"
+  /api/s3/getExecutionsFilesPresignedUrls:
+    post:
+      description: API Endpoint to use S3 Presigned URLs to retrieve result files from S3 given an execution id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - exec_id
+              properties:
+                exec_id:
+                  type: string
+                  description: The execution id
+              example:
+                exec_id: '1234'
+        required: true
+      responses:
+        "200":
+          description: Result files for your execution fetched successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Result file fetch successful"
+        "400":
+          description: Result file fetch didn't go through successfully. This is usually something wrong with your code
+        "401":
+          description: User is not authenticated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "User is not authenticated"
+  /api/s3/getUserDatasetFilesData:
+    post: 
+      description: API Endpoint to retrieve all user dataset files uploaded in S3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object 
+              required: 
+                - uid
+                - data_source 
+              properties:
+                uid: 
+                  type: string 
+                  description: User ID 
+                data_source: 
+                  type: string 
+                  description: 'What type of training was the user running (eg: TABULAR, PRETRAINED, OBJECT_DETECTION, IMAGE, etc)'
+      responses:
+        "200":
+          description: User Dataset files for user fetched successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "User Dataset file fetch successful"
+        "400":
+          description: User Dataset files for user wasn't fetched successfully. This is usually something wrong with your code
+        "401":
+          description: User is not authenticated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "User is not authenticated"

--- a/openapi/test_endpoints.yaml
+++ b/openapi/test_endpoints.yaml
@@ -1,0 +1,20 @@
+openapi: "3.0.0"
+info:
+  title: DLP API
+  description: API endpoints for the Deep Learning Playground Project
+  version: "1.0.0"
+paths:
+  /api/test:
+    get:
+      summary: A simple endpoint to test if our backend is alive
+      responses:
+        200: 
+          description: Test Backend alive
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Status:
+                    type: string 
+                    example: "Backend is alive"

--- a/openapi/trainspace_endpoints.yaml
+++ b/openapi/trainspace_endpoints.yaml
@@ -1,0 +1,86 @@
+openapi: "3.0.0"
+info:
+  title: DLP API
+  description: API endpoints for the Deep Learning Playground Project
+  version: "1.0.0"
+paths:
+  /api/trainspace/create-trainspace:
+    post:
+      description:  API Endpoint to create a "trainspace". Trainspace is a new concept/data structure we introduce to track user's training requests. Concept similar to execution_id.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - uid
+              properties:
+                uid:
+                  type: string
+                  description: User ID
+              example:
+                uid: '1234'
+        required: true
+      responses:
+        "200":
+          description: Trainspace created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Trainspace Creation successful"
+        "400":
+          description: Trainspace Creation didn't go through successfully. This is usually something wrong with your code
+        "401":
+          description: User is not authenticated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "User is not authenticated"
+  /api/trainspace/getTrainspaceData:
+    post:
+      description:  API Endpoint to identify all trainspaces for a given user id.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - uid
+              properties:
+                uid:
+                  type: string
+                  description: User ID
+              example:
+                uid: '1234'
+        required: true
+      responses:
+        "200":
+          description: Able to query and retrieve trainspace objects belonging to a user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Trainspace Retrieval Successful"
+        "400":
+          description: Trainspace Retrieval didn't go through successfully. This is usually something wrong with your code
+        "401":
+          description: User is not authenticated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "User is not authenticated"


### PR DESCRIPTION
# API documentation migrating to Redocly instead of local Swagger UI

**What user problem are we solving?**
Swagger UI too confusing to setup and the UI looks a bit ugly. Fortunately, there is a better solution called [Redocly](https://redocly.com/docs/cli/).
**What solution does this PR provide?**
Provide the `/openapi` directory containing our api documentation for Redocly to ingest and display beautifully

**Testing Methodology**
* Validation of `*.yaml` files under `openapi/` directory using VSCode
* Open API Validation Github Action that runs on push or pull request of any files under `openapi/`
**Any other considerations**
make sure redocly works for our case and we aren't incurring extra cost