### PR TITLE
Add info icon and simplified descriptions for terms in Layers Inventory

### DIFF
--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -45,7 +45,7 @@ const Home = () => {
 
   // input responses
   const [customModelName, setCustomModelName] = useState(
-    `Model ${new Date().toLocaleString()}`
+    `Model ${new Date().toLocaleString()}`,
   );
   const [fileURL, setFileURL] = useState("");
   const [notificationPhoneNumber, setNotificationPhoneNumber] = useState();
@@ -55,11 +55,11 @@ const Home = () => {
   const [features, setFeatures] = useState([]);
   const [problemType, setProblemType] = useState(PROBLEM_TYPES[0]);
   const [criterion, setCriterion] = useState(
-    problemType === PROBLEM_TYPES[0] ? CRITERIONS[3] : CRITERIONS[0]
+    problemType === PROBLEM_TYPES[0] ? CRITERIONS[3] : CRITERIONS[0],
   );
   const [optimizerName, setOptimizerName] = useState(OPTIMIZER_NAMES[0]);
   const [usingDefaultDataset, setUsingDefaultDataset] = useState(
-    DEFAULT_DATASETS[0]
+    DEFAULT_DATASETS[0],
   );
   const [shuffle, setShuffle] = useState(BOOL_OPTIONS[1]);
   const [epochs, setEpochs] = useState(5);
@@ -69,7 +69,7 @@ const Home = () => {
     uploadedColumns.map((e, i) => ({
       label: e.name,
       value: i,
-    }))
+    })),
   );
   const [activeColumns, setActiveColumns] = useState([]);
   const [beginnerMode, setBeginnerMode] = useState(true);
@@ -151,7 +151,7 @@ const Home = () => {
     {
       queryText: "Criterion",
       options: CRITERIONS.filter((crit) =>
-        crit.problem_type.includes(problemType.value)
+        crit.problem_type.includes(problemType.value),
       ),
       onChange: setCriterion,
       defaultValue: criterion,
@@ -193,7 +193,7 @@ const Home = () => {
 
   useEffect(() => {
     setCriterion(
-      problemType === PROBLEM_TYPES[0] ? CRITERIONS[3] : CRITERIONS[0]
+      problemType === PROBLEM_TYPES[0] ? CRITERIONS[3] : CRITERIONS[0],
     );
     setInputKey((e) => e + 1);
   }, [problemType]);
@@ -356,7 +356,7 @@ const Home = () => {
         problemType={problemType}
       />
     ),
-    [dlpBackendResponse, problemType]
+    [dlpBackendResponse, problemType],
   );
 
   return (

--- a/frontend/src/components_old/ClassicalMLModel/ClassicalMLModel.js
+++ b/frontend/src/components_old/ClassicalMLModel/ClassicalMLModel.js
@@ -31,11 +31,11 @@ import DataTable from "react-data-table-component";
 
 const ClassicalMLModel = () => {
   const [customModelName, setCustomModelName] = useState(
-    `Model ${new Date().toLocaleString()}`
+    `Model ${new Date().toLocaleString()}`,
   );
   const [addedLayers, setAddedLayers] = useState([]);
   const [usingDefaultDataset, setUsingDefaultDataset] = useState(
-    DEFAULT_DATASETS[0]
+    DEFAULT_DATASETS[0],
   );
   const [shuffle, setShuffle] = useState(BOOL_OPTIONS[1]);
   const [email, setEmail] = useState("");
@@ -56,7 +56,7 @@ const ClassicalMLModel = () => {
     uploadedColumns.map((e, i) => ({
       label: e.name,
       value: i,
-    }))
+    })),
   );
   const input_responses = {
     shuffle: shuffle?.value,
@@ -138,7 +138,7 @@ const ClassicalMLModel = () => {
         choice="classicalml"
       />
     ),
-    [dlpBackendResponse, PROBLEM_TYPES[0]]
+    [dlpBackendResponse, PROBLEM_TYPES[0]],
   );
 
   const onClick = () => {

--- a/frontend/src/components_old/ImageModels/ImageModels.js
+++ b/frontend/src/components_old/ImageModels/ImageModels.js
@@ -38,7 +38,7 @@ import {
 
 const ImageModels = () => {
   const [customModelName, setCustomModelName] = useState(
-    `Model ${new Date().toLocaleString()}`
+    `Model ${new Date().toLocaleString()}`,
   );
   const [addedLayers, setAddedLayers] = useState(DEFAULT_IMG_LAYERS);
   const [trainTransforms, setTrainTransforms] = useState(DEFAULT_TRANSFORMS);
@@ -121,7 +121,7 @@ const ImageModels = () => {
         problemType={PROBLEM_TYPES[0]}
       />
     ),
-    [dlpBackendResponse, PROBLEM_TYPES[0]]
+    [dlpBackendResponse, PROBLEM_TYPES[0]],
   );
 
   const onClick = () => {

--- a/frontend/src/components_old/LearnMod/Exercise.js
+++ b/frontend/src/components_old/LearnMod/Exercise.js
@@ -40,11 +40,11 @@ const Exercise = (props) => {
   const [features, setFeatures] = useState([]);
   const [problemType, setProblemType] = useState(PROBLEM_TYPES[0]);
   const [criterion, setCriterion] = useState(
-    problemType === PROBLEM_TYPES[0] ? CRITERIONS[3] : CRITERIONS[0]
+    problemType === PROBLEM_TYPES[0] ? CRITERIONS[3] : CRITERIONS[0],
   );
   const [optimizerName, setOptimizerName] = useState(OPTIMIZER_NAMES[0]);
   const [usingDefaultDataset, setUsingDefaultDataset] = useState(
-    DEFAULT_DATASETS[0]
+    DEFAULT_DATASETS[0],
   );
   const [shuffle, setShuffle] = useState(BOOL_OPTIONS[1]);
   const [epochs, setEpochs] = useState(5);
@@ -54,7 +54,7 @@ const Exercise = (props) => {
     uploadedColumns.map((e, i) => ({
       label: e.name,
       value: i,
-    }))
+    })),
   );
   const [activeColumns, setActiveColumns] = useState([]);
   const [finalAccuracy, setFinalAccuracy] = useState("");
@@ -128,7 +128,7 @@ const Exercise = (props) => {
     {
       queryText: "Criterion",
       options: CRITERIONS.filter((crit) =>
-        crit.problem_type.includes(problemType.value)
+        crit.problem_type.includes(problemType.value),
       ),
       onChange: setCriterion,
       defaultValue: criterion,
@@ -182,7 +182,7 @@ const Exercise = (props) => {
 
   useEffect(() => {
     setCriterion(
-      problemType === PROBLEM_TYPES[0] ? CRITERIONS[3] : CRITERIONS[0]
+      problemType === PROBLEM_TYPES[0] ? CRITERIONS[3] : CRITERIONS[0],
     );
     setInputKey((e) => e + 1);
   }, [problemType]);
@@ -220,7 +220,7 @@ const Exercise = (props) => {
   useEffect(() => {
     if (dlpBackendResponse != null) {
       setFinalAccuracy(
-        dlpBackendResponse["dl_results"][epochs - 1]["train_acc"]
+        dlpBackendResponse["dl_results"][epochs - 1]["train_acc"],
       );
     }
 
@@ -303,7 +303,7 @@ const Exercise = (props) => {
         />
       </div>
     ),
-    [dlpBackendResponse, problemType]
+    [dlpBackendResponse, problemType],
   );
 
   return (

--- a/frontend/src/components_old/ObjectDetection/ObjectDetection.js
+++ b/frontend/src/components_old/ObjectDetection/ObjectDetection.js
@@ -28,7 +28,7 @@ import FilerobotImageEditor, {
 
 const ObjectDetection = () => {
   const [customModelName, setCustomModelName] = useState(
-    `Model ${new Date().toLocaleString()}`
+    `Model ${new Date().toLocaleString()}`,
   );
   const [problemType, setProblemType] = useState("");
   const [detectionType, setDetectionType] = useState("");
@@ -37,7 +37,7 @@ const ObjectDetection = () => {
   const [inputKey, setInputKey] = useState(0);
   const [uploadFile, setUploadFile] = useState(null);
   const [imageTransforms, setImageTransforms] = useState(
-    DEFAULT_DETECTION_TRANSFORMS
+    DEFAULT_DETECTION_TRANSFORMS,
   );
 
   const input_responses = {
@@ -71,7 +71,7 @@ const ObjectDetection = () => {
         choice="objectdetection"
       />
     ),
-    [dlpBackendResponse, OBJECT_DETECTION_PROBLEM_TYPES[0]]
+    [dlpBackendResponse, OBJECT_DETECTION_PROBLEM_TYPES[0]],
   );
 
   const onClick = () => {
@@ -126,7 +126,7 @@ const ObjectDetection = () => {
         onSave={(editedImageObject) => {
           const file = dataURLtoFile(
             editedImageObject.imageBase64,
-            editedImageObject.fullName
+            editedImageObject.fullName,
           );
           setUploadFile(file);
         }}

--- a/frontend/src/features/Train/features/Image/components/ImageParametersStep.tsx
+++ b/frontend/src/features/Train/features/Image/components/ImageParametersStep.tsx
@@ -57,8 +57,6 @@ import {
 import ClientOnlyPortal from "@/common/components/ClientOnlyPortal";
 import { updateImageTrainspaceData } from "../redux/imageActions";
 
-
-
 const HtmlTooltip = styled(
   ({
     className,
@@ -84,1184 +82,1196 @@ const HtmlTooltip = styled(
   },
 }));
 
-
 const ImageParametersStep = ({
-    renderStepperButtons,
-    setIsModified,
-  }: {
-    renderStepperButtons: (
-      submitTrainspace: (data: TrainspaceData<"PARAMETERS">) => void
-    ) => React.ReactNode;
-    setIsModified: React.Dispatch<React.SetStateAction<boolean>>;
-  }) => {
-    const trainspace = useAppSelector(
-      (state) =>
-        state.trainspace.current as TrainspaceData<"PARAMETERS"> | undefined
-    );
-    const dispatch = useAppDispatch();
-    const {
-      handleSubmit,
-      formState: { errors, isDirty },
-      control,
-    } = useForm<ParameterData>({
-      defaultValues: {
-        criterion: trainspace?.parameterData?.criterion ?? "CELOSS",
-        optimizerName: trainspace?.parameterData?.optimizerName ?? "SGD",
-        shuffle: trainspace?.parameterData?.shuffle ?? true,
-        epochs: trainspace?.parameterData?.epochs ?? 5,
-        batchSize: trainspace?.parameterData?.batchSize ?? 20,
-        trainTransforms: trainspace?.parameterData?.trainTransforms ?? [
-          {
-            value: "GRAYSCALE",
-            parameters: [],
-          },
-          {
-            value: "TO_TENSOR",
-            parameters: [],
-          },
-          {
-            value: "RESIZE",
-            parameters: [32, 32],
-          },
-        ],
-        testTransforms: trainspace?.parameterData?.testTransforms ?? [
-          {
-            value: "GRAYSCALE",
-            parameters: [],
-          },
-          {
-            value: "TO_TENSOR",
-            parameters: [],
-          },
-          {
-            value: "RESIZE",
-            parameters: [32, 32],
-          },
-        ],
-        layers: trainspace?.parameterData?.layers ?? [
-          {
-            value: "CONV2D",
-            parameters: [1, 5, 3, 1, 1],
-          },
-          {
-            value: "MAXPOOL2D",
-            parameters: [3, 1],
-          },
-          {
-            value: "FLATTEN",
-            parameters: [1, -1],
-          },
-          {
-            value: "LINEAR",
-            parameters: [500, 10],
-          },
-          {
-            value: "SIGMOID",
-            parameters: [],
-          },
-        ],
-      },
-    });
-    useEffect(() => {
-      setIsModified(isDirty);
-    }, [isDirty]);
-    if (!trainspace) return <></>;
-    return (
-      <Stack spacing={3}>
-        <Controller
-          name="criterion"
-          control={control}
-          rules={{ required: true }}
-          render={({ field: { onChange, value } }) => (
-            <TextField select label="Criterion" onChange={onChange} value={value}>
-              {STEP_SETTINGS["PARAMETERS"].criterions.map((criterion) => (
-                <MenuItem key={criterion.value} value={criterion.value}>
-                  {criterion.label}
-                </MenuItem>
-              ))}
-            </TextField>
-          )}
-        />
-        <Controller
-          name="optimizerName"
-          control={control}
-          rules={{ required: true }}
-          render={({ field: { onChange, value } }) => (
-            <TextField select label="Optimizer" onChange={onChange} value={value}>
-              {STEP_SETTINGS["PARAMETERS"].optimizers.map((optimizer) => (
-                <MenuItem key={optimizer.value} value={optimizer.value}>
-                  {optimizer.label}
-                </MenuItem>
-              ))}
-            </TextField>
-          )}
-        />
-        <FormGroup>
-          <Controller
-            name="shuffle"
-            control={control}
-            rules={{ required: true }}
-            render={({ field: { onChange, value } }) => (
-              <FormControlLabel
-                control={
-                  <Switch value={value} onChange={onChange} defaultChecked />
-                }
-                label="Shuffle"
-              />
-            )}
-          />
-        </FormGroup>
-        <Controller
-          name="epochs"
-          control={control}
-          rules={{ required: true }}
-          render={({ field: { onChange, value } }) => (
-            <TextField
-              label="Epochs"
-              type={"number"}
-              onChange={onChange}
-              value={value}
-            />
-          )}
-        />
-        <Controller
-          name="batchSize"
-          control={control}
-          rules={{ required: true }}
-          render={({ field: { onChange, value } }) => (
-            <TextField
-              label="Batch Size"
-              type={"number"}
-              onChange={onChange}
-              value={value}
-            />
-          )}
-        />
-        <TrainTransformsDnd control={control} errors={errors} />
-        <TestTransformsDnd control={control} errors={errors} />
-        <LayersDnd control={control} errors={errors} />
-        {renderStepperButtons((trainspaceData) => {
-          handleSubmit((data) => {
-            dispatch(
-              updateImageTrainspaceData({
-                current: {
-                  ...trainspaceData,
-                  parameterData: data,
-                  reviewData: undefined,
-                },
-                stepLabel: "PARAMETERS",
-              })
-            );
-          })();
-        })}
-      </Stack>
-    );
-  };
-  
-  const LayersDnd = ({
+  renderStepperButtons,
+  setIsModified,
+}: {
+  renderStepperButtons: (
+    submitTrainspace: (data: TrainspaceData<"PARAMETERS">) => void
+  ) => React.ReactNode;
+  setIsModified: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+  const trainspace = useAppSelector(
+    (state) =>
+      state.trainspace.current as TrainspaceData<"PARAMETERS"> | undefined
+  );
+  const dispatch = useAppDispatch();
+  const {
+    handleSubmit,
+    formState: { errors, isDirty },
     control,
-    errors,
-  }: {
-    control: Control<ParameterData, unknown>;
-    errors: FieldErrors<ParameterData>;
-  }) => {
-    const { fields, move, insert, remove } = useFieldArray({
-      control: control,
-      name: "layers",
-    });
-    const genLayerInvIds = () =>
-      Object.fromEntries(
-        STEP_SETTINGS.PARAMETERS.layerValues.map((layerValue) => [
-          layerValue,
-          Math.floor(Math.random() * Date.now()),
-        ])
-      );
-    const [layerInvIds, setLayerInvIds] = useState<{
-      [layerValue: string]: number;
-    }>(genLayerInvIds());
-    const [dndActive, setDndActive] = useState<Active | null>(null);
-    const [invHovering, setInvHovering] = useState<boolean>(false);
-  
-    const dndActiveItem = useMemo(() => {
-      if (!dndActive) return;
-      if (dndActive.data.current && "inventory" in dndActive.data.current) {
-        const value = dndActive.data.current.inventory
-          .value as (typeof STEP_SETTINGS.PARAMETERS.layerValues)[number];
-        return {
-          id: layerInvIds[value],
-          value: value,
-          parameters: STEP_SETTINGS.PARAMETERS.layers[value].parameters.map(
-            () => ""
-          ) as ""[],
-        };
-      } else if (dndActive.data.current && "sortable" in dndActive.data.current) {
-        return fields[dndActive.data.current.sortable.index];
-      }
-    }, [dndActive]);
-    const sensors = useSensors(
-      useCustomPointerSensor(),
-      useCustomKeyboardSensor({ coordinateGetter: sortableKeyboardCoordinates })
+  } = useForm<ParameterData>({
+    defaultValues: {
+      criterion: trainspace?.parameterData?.criterion ?? "CELOSS",
+      optimizerName: trainspace?.parameterData?.optimizerName ?? "SGD",
+      shuffle: trainspace?.parameterData?.shuffle ?? true,
+      epochs: trainspace?.parameterData?.epochs ?? 5,
+      batchSize: trainspace?.parameterData?.batchSize ?? 20,
+      trainTransforms: trainspace?.parameterData?.trainTransforms ?? [
+        {
+          value: "GRAYSCALE",
+          parameters: [],
+        },
+        {
+          value: "TO_TENSOR",
+          parameters: [],
+        },
+        {
+          value: "RESIZE",
+          parameters: [32, 32],
+        },
+      ],
+      testTransforms: trainspace?.parameterData?.testTransforms ?? [
+        {
+          value: "GRAYSCALE",
+          parameters: [],
+        },
+        {
+          value: "TO_TENSOR",
+          parameters: [],
+        },
+        {
+          value: "RESIZE",
+          parameters: [32, 32],
+        },
+      ],
+      layers: trainspace?.parameterData?.layers ?? [
+        {
+          value: "CONV2D",
+          parameters: [1, 5, 3, 1, 1],
+        },
+        {
+          value: "MAXPOOL2D",
+          parameters: [3, 1],
+        },
+        {
+          value: "FLATTEN",
+          parameters: [1, -1],
+        },
+        {
+          value: "LINEAR",
+          parameters: [500, 10],
+        },
+        {
+          value: "SIGMOID",
+          parameters: [],
+        },
+      ],
+    },
+  });
+  useEffect(() => {
+    setIsModified(isDirty);
+  }, [isDirty]);
+  if (!trainspace) return <></>;
+  return (
+    <Stack spacing={3}>
+      <Controller
+        name="criterion"
+        control={control}
+        rules={{ required: true }}
+        render={({ field: { onChange, value } }) => (
+          <TextField select label="Criterion" onChange={onChange} value={value}>
+            {STEP_SETTINGS["PARAMETERS"].criterions.map((criterion) => (
+              <MenuItem key={criterion.value} value={criterion.value}>
+                {criterion.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
+      />
+      <Controller
+        name="optimizerName"
+        control={control}
+        rules={{ required: true }}
+        render={({ field: { onChange, value } }) => (
+          <TextField select label="Optimizer" onChange={onChange} value={value}>
+            {STEP_SETTINGS["PARAMETERS"].optimizers.map((optimizer) => (
+              <MenuItem key={optimizer.value} value={optimizer.value}>
+                {optimizer.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
+      />
+      <FormGroup>
+        <Controller
+          name="shuffle"
+          control={control}
+          rules={{ required: true }}
+          render={({ field: { onChange, value } }) => (
+            <FormControlLabel
+              control={
+                <Switch value={value} onChange={onChange} defaultChecked />
+              }
+              label="Shuffle"
+            />
+          )}
+        />
+      </FormGroup>
+      <Controller
+        name="epochs"
+        control={control}
+        rules={{ required: true }}
+        render={({ field: { onChange, value } }) => (
+          <TextField
+            label="Epochs"
+            type={"number"}
+            onChange={onChange}
+            value={value}
+          />
+        )}
+      />
+      <Controller
+        name="batchSize"
+        control={control}
+        rules={{ required: true }}
+        render={({ field: { onChange, value } }) => (
+          <TextField
+            label="Batch Size"
+            type={"number"}
+            onChange={onChange}
+            value={value}
+          />
+        )}
+      />
+      <TrainTransformsDnd control={control} errors={errors} />
+      <TestTransformsDnd control={control} errors={errors} />
+      <LayersDnd control={control} errors={errors} />
+      {renderStepperButtons((trainspaceData) => {
+        handleSubmit((data) => {
+          dispatch(
+            updateImageTrainspaceData({
+              current: {
+                ...trainspaceData,
+                parameterData: data,
+                reviewData: undefined,
+              },
+              stepLabel: "PARAMETERS",
+            })
+          );
+        })();
+      })}
+    </Stack>
+  );
+};
+
+const LayersDnd = ({
+  control,
+  errors,
+}: {
+  control: Control<ParameterData, unknown>;
+  errors: FieldErrors<ParameterData>;
+}) => {
+  const { fields, move, insert, remove } = useFieldArray({
+    control: control,
+    name: "layers",
+  });
+  const genLayerInvIds = () =>
+    Object.fromEntries(
+      STEP_SETTINGS.PARAMETERS.layerValues.map((layerValue) => [
+        layerValue,
+        Math.floor(Math.random() * Date.now()),
+      ])
     );
-    return (
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragStart={({ active }) => {
-          if (dndActive !== null) return;
-          setDndActive(active);
-        }}
-        onDragOver={({ over }) => {
-          if (!over || !over.data.current) {
-            setInvHovering(false);
-            return;
-          }
-          if (!invHovering) {
-            setInvHovering(true);
-          }
-        }}
-        onDragEnd={({ active, over }) => {
-          if (dndActive && dndActive.data.current && dndActiveItem) {
-            if (
-              "inventory" in dndActive.data.current &&
-              over?.data.current &&
-              "sortable" in over.data.current
-            ) {
-              insert(over.data.current.sortable.index, {
-                value: dndActiveItem.value,
-                parameters: dndActiveItem.parameters as number[],
-              });
-            } else if (
-              "sortable" in dndActive.data.current &&
-              over?.data.current &&
-              "sortable" in over.data.current
-            ) {
-              move(
-                fields.findIndex((field) => field.id === active.id),
-                fields.findIndex((field) => field.id === over.id)
-              );
-            }
-          }
-          setLayerInvIds(genLayerInvIds());
+  const [layerInvIds, setLayerInvIds] = useState<{
+    [layerValue: string]: number;
+  }>(genLayerInvIds());
+  const [dndActive, setDndActive] = useState<Active | null>(null);
+  const [invHovering, setInvHovering] = useState<boolean>(false);
+
+  const dndActiveItem = useMemo(() => {
+    if (!dndActive) return;
+    if (dndActive.data.current && "inventory" in dndActive.data.current) {
+      const value = dndActive.data.current.inventory
+        .value as (typeof STEP_SETTINGS.PARAMETERS.layerValues)[number];
+      return {
+        id: layerInvIds[value],
+        value: value,
+        parameters: STEP_SETTINGS.PARAMETERS.layers[value].parameters.map(
+          () => ""
+        ) as ""[],
+      };
+    } else if (dndActive.data.current && "sortable" in dndActive.data.current) {
+      return fields[dndActive.data.current.sortable.index];
+    }
+  }, [dndActive]);
+  const sensors = useSensors(
+    useCustomPointerSensor(),
+    useCustomKeyboardSensor({ coordinateGetter: sortableKeyboardCoordinates })
+  );
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={({ active }) => {
+        if (dndActive !== null) return;
+        setDndActive(active);
+      }}
+      onDragOver={({ over }) => {
+        if (!over || !over.data.current) {
           setInvHovering(false);
-          setDndActive(null);
-        }}
-        onDragCancel={({ active }) => {
-          if (active.data.current && "inventory" in active.data.current) {
-            const index = fields.findIndex((field) => field.id === active.id);
-            if (index !== -1) {
-              remove(fields.findIndex((field) => field.id === active.id));
-            }
+          return;
+        }
+        if (!invHovering) {
+          setInvHovering(true);
+        }
+      }}
+      onDragEnd={({ active, over }) => {
+        if (dndActive && dndActive.data.current && dndActiveItem) {
+          if (
+            "inventory" in dndActive.data.current &&
+            over?.data.current &&
+            "sortable" in over.data.current
+          ) {
+            insert(over.data.current.sortable.index, {
+              value: dndActiveItem.value,
+              parameters: dndActiveItem.parameters as number[],
+            });
+          } else if (
+            "sortable" in dndActive.data.current &&
+            over?.data.current &&
+            "sortable" in over.data.current
+          ) {
+            move(
+              fields.findIndex((field) => field.id === active.id),
+              fields.findIndex((field) => field.id === over.id)
+            );
           }
-          setLayerInvIds(genLayerInvIds());
-          setInvHovering(false);
-          setDndActive(null);
-        }}
-      >
-        <Paper elevation={1} style={{ backgroundColor: "transparent" }}>
-          <Stack alignItems={"center"} spacing={2} padding={2}>
-            <Typography variant="h2" fontSize={25}>
-              Layers
-            </Typography>
-            <Stack direction={"row"} spacing={3}>
-              {STEP_SETTINGS.PARAMETERS.layerValues.map((value) => (
-                <LayerInventoryComponent
-                  id={layerInvIds[value]}
-                  key={value}
-                  value={value}
-                />
-              ))}
-            </Stack>
+        }
+        setLayerInvIds(genLayerInvIds());
+        setInvHovering(false);
+        setDndActive(null);
+      }}
+      onDragCancel={({ active }) => {
+        if (active.data.current && "inventory" in active.data.current) {
+          const index = fields.findIndex((field) => field.id === active.id);
+          if (index !== -1) {
+            remove(fields.findIndex((field) => field.id === active.id));
+          }
+        }
+        setLayerInvIds(genLayerInvIds());
+        setInvHovering(false);
+        setDndActive(null);
+      }}
+    >
+      <Paper elevation={1} style={{ backgroundColor: "transparent" }}>
+        <Stack alignItems={"center"} spacing={2} padding={2}>
+          <Typography variant="h2" fontSize={25}>
+            Layers
+          </Typography>
+          <Stack direction={"row"} spacing={3}>
+            {STEP_SETTINGS.PARAMETERS.layerValues.map((value) => (
+              <LayerInventoryComponent
+                id={layerInvIds[value]}
+                key={value}
+                value={value}
+              />
+            ))}
           </Stack>
-        </Paper>
-  
-        <Container>
-          <Stack spacing={0}>
-            <SortableContext
-              items={
+        </Stack>
+      </Paper>
+
+      <Container>
+        <Stack spacing={0}>
+          <SortableContext
+            items={
+              dndActiveItem &&
+              dndActive?.data.current &&
+              "inventory" in dndActive.data.current
+                ? [dndActiveItem, ...fields]
+                : fields
+            }
+            strategy={verticalListSortingStrategy}
+          >
+            {fields.length > 0 ? (
+              [
                 dndActiveItem &&
                 dndActive?.data.current &&
-                "inventory" in dndActive.data.current
-                  ? [dndActiveItem, ...fields]
-                  : fields
-              }
-              strategy={verticalListSortingStrategy}
-            >
-              {fields.length > 0 ? (
-                [
-                  dndActiveItem &&
-                  dndActive?.data.current &&
-                  "inventory" in dndActive.data.current &&
-                  invHovering ? (
-                    <LayerComponent
-                      key={dndActiveItem.id}
-                      id={dndActiveItem.id}
-                      data={dndActiveItem as ParameterData["layers"][number]}
-                    />
-                  ) : null,
-                  ...fields.map((field, index) => (
-                    <LayerComponent
-                      key={field.id}
-                      id={field.id}
-                      data={field}
-                      formProps={{
-                        index: index,
-                        control: control,
-                        errors: errors,
-                        remove: () => remove(index),
-                      }}
-                    />
-                  )),
-                ]
-              ) : (
-                <Card>This is Unimplemented</Card>
-              )}
-            </SortableContext>
-          </Stack>
-        </Container>
-  
-        <ClientOnlyPortal selector="#portal">
-          <DragOverlay style={{ width: undefined }}>
-            {dndActiveItem ? (
-              dndActive?.data.current && "sortable" in dndActive.data.current ? (
-                <LayerComponent
-                  data={dndActiveItem as ParameterData["layers"][number]}
-                  formProps={{
-                    index: dndActive.data.current.sortable.index,
-                    control: control,
-                    errors: errors,
-                  }}
-                />
-              ) : (
-                <LayerComponent
-                  data={dndActiveItem as ParameterData["layers"][number]}
-                />
-              )
-            ) : null}
-          </DragOverlay>
-        </ClientOnlyPortal>
-      </DndContext>
-    );
-  };
-  
-  const LayerComponent = ({
-    id,
-    data,
-    formProps,
-  }: {
-    id?: string | number;
-    data: ParameterData["layers"][number];
-    formProps?: {
-      index: number;
-      control: Control<ParameterData, unknown>;
-      errors: FieldErrors<ParameterData>;
-      remove?: () => void;
-    };
-  }) => {
-    const {
-      attributes,
-      listeners,
-      setNodeRef,
-      isDragging,
-      transform,
-      transition,
-    } = id
-      ? useSortable({ id })
-      : {
-          attributes: undefined,
-          listeners: undefined,
-          setNodeRef: undefined,
-          isDragging: undefined,
-          transform: undefined,
-          transition: undefined,
-        };
-    const style = transform
-      ? {
-          opacity: isDragging ? 0.4 : undefined,
-          transform: CSS.Transform.toString(transform),
-          transition: transition,
-        }
-      : undefined;
-    return (
-      <div ref={setNodeRef}>
-        <Card
-          sx={{ p: 3 }}
-          style={{ ...{ display: "inline-block" }, ...style }}
-          {...attributes}
-          {...listeners}
-        >
-          <Stack
-            direction={"row"}
-            justifyContent={"space-between"}
-            alignItems={"center"}
-            spacing={3}
-          >
-            <HtmlTooltip
-              title={
-                <React.Fragment>
-                  <Typography color="inherit">
-                    {STEP_SETTINGS.PARAMETERS.layers[data.value].label}
-                  </Typography>
-                  {STEP_SETTINGS.PARAMETERS.layers[data.value].description}
-                </React.Fragment>
-              }
-            >
-              <InfoIcon>Info</InfoIcon>
-            </HtmlTooltip>
+                "inventory" in dndActive.data.current &&
+                invHovering ? (
+                  <LayerComponent
+                    key={dndActiveItem.id}
+                    id={dndActiveItem.id}
+                    data={dndActiveItem as ParameterData["layers"][number]}
+                  />
+                ) : null,
+                ...fields.map((field, index) => (
+                  <LayerComponent
+                    key={field.id}
+                    id={field.id}
+                    data={field}
+                    formProps={{
+                      index: index,
+                      control: control,
+                      errors: errors,
+                      remove: () => remove(index),
+                    }}
+                  />
+                )),
+              ]
+            ) : (
+              <Card>This is Unimplemented</Card>
+            )}
+          </SortableContext>
+        </Stack>
+      </Container>
 
+      <ClientOnlyPortal selector="#portal">
+        <DragOverlay style={{ width: undefined }}>
+          {dndActiveItem ? (
+            dndActive?.data.current && "sortable" in dndActive.data.current ? (
+              <LayerComponent
+                data={dndActiveItem as ParameterData["layers"][number]}
+                formProps={{
+                  index: dndActive.data.current.sortable.index,
+                  control: control,
+                  errors: errors,
+                }}
+              />
+            ) : (
+              <LayerComponent
+                data={dndActiveItem as ParameterData["layers"][number]}
+              />
+            )
+          ) : null}
+        </DragOverlay>
+      </ClientOnlyPortal>
+    </DndContext>
+  );
+};
 
-            <Typography variant="h3" fontSize={18}>
-              {STEP_SETTINGS.PARAMETERS.layers[data.value].label}
-            </Typography>
-            <Stack direction={"row"} alignItems={"center"} spacing={3}>
-              <Stack
-                direction={"row"}
-                alignItems={"center"}
-                justifyContent={"flex-end"}
-                spacing={2}
-                divider={<Divider orientation="vertical" flexItem />}
-              >
-                {STEP_SETTINGS.PARAMETERS.layers[data.value].parameters.map(
-                  (parameter, index) => (
-                    <div key={index} data-no-dnd>
-                      {formProps ? (
-                        <Controller
-                          name={`layers.${formProps.index}.parameters.${index}`}
-                          control={formProps.control}
-                          rules={{ required: true }}
-                          render={({ field: { onChange, value } }) => (
-                            <TextField
-                              label={parameter.label}
-                              size={"small"}
-                              style={{ minWidth: "124px" }}
-                              type={parameter.type}
-                              onChange={onChange}
-                              value={value}
-                              required
-                              error={
-                                formProps.errors.layers?.[formProps.index]
-                                  ?.parameters?.[index]
-                                  ? true
-                                  : false
-                              }
-                            />
-                          )}
-                        />
-                      ) : (
-                        <TextField
-                          label={parameter.label}
-                          size={"small"}
-                          type={parameter.type}
-                          value={""}
-                          required
-                        />
-                      )}
-                    </div>
-                  )
-                )}
-              </Stack>
-              <div data-no-dnd>
-                <IconButton onClick={formProps?.remove}>
-                  <DeleteIcon />
-                </IconButton>
-              </div>
-            </Stack>
-          </Stack>
-        </Card>
-      </div>
-    );
-  };
-  
-  const LayerInventoryComponent = ({
-    id,
-    value,
-  }: {
-    id: number;
-    value: (typeof STEP_SETTINGS.PARAMETERS.layerValues)[number];
-  }) => {
-    const { attributes, listeners, isDragging, setNodeRef } = useDraggable({
-      id: id,
-      data: {
-        inventory: {
-          value,
-        },
-      },
-    });
-  
-    const style = {
-      opacity: isDragging ? 0.4 : undefined,
-    };
-    return (
-      <div ref={setNodeRef}>
-        <Card
-          sx={{ p: 1 }}
-          style={{ ...{ display: "inline-block" }, ...style }}
-          {...attributes}
-          {...listeners}
-        >
-          {STEP_SETTINGS.PARAMETERS.layers[value].label}
-        </Card>
-      </div>
-    );
-  };
-
-  const TrainTransformsDnd = ({
-    control,
-    errors,
-  }: {
+const LayerComponent = ({
+  id,
+  data,
+  formProps,
+}: {
+  id?: string | number;
+  data: ParameterData["layers"][number];
+  formProps?: {
+    index: number;
     control: Control<ParameterData, unknown>;
     errors: FieldErrors<ParameterData>;
-  }) => {
-    const { fields, move, insert, remove } = useFieldArray({
-      control: control,
-      name: "trainTransforms",
-    });
-    const genTransformInvIds = () =>
-      Object.fromEntries(
-        STEP_SETTINGS.PARAMETERS.transformValues.map((transformValue) => [
-          transformValue,
-          Math.floor(Math.random() * Date.now()),
-        ])
-      );
-    const [transformInvIds, setTransformInvIds] = useState<{
-      [transformValue: string]: number;
-    }>(genTransformInvIds());
-    const [dndActive, setDndActive] = useState<Active | null>(null);
-    const [invHovering, setInvHovering] = useState<boolean>(false);
-  
-    const dndActiveItem = useMemo(() => {
-      if (!dndActive) return;
-      if (dndActive.data.current && "inventory" in dndActive.data.current) {
-        const value = dndActive.data.current.inventory
-          .value as (typeof STEP_SETTINGS.PARAMETERS.transformValues)[number];
-        return {
-          id: transformInvIds[value],
-          value: value,
-          parameters: STEP_SETTINGS.PARAMETERS.transforms[value].parameters.map(
-            () => ""
-          ) as ""[],
-        };
-      } else if (dndActive.data.current && "sortable" in dndActive.data.current) {
-        return fields[dndActive.data.current.sortable.index];
+    remove?: () => void;
+  };
+}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    isDragging,
+    transform,
+    transition,
+  } = id
+    ? useSortable({ id })
+    : {
+        attributes: undefined,
+        listeners: undefined,
+        setNodeRef: undefined,
+        isDragging: undefined,
+        transform: undefined,
+        transition: undefined,
+      };
+  const style = transform
+    ? {
+        opacity: isDragging ? 0.4 : undefined,
+        transform: CSS.Transform.toString(transform),
+        transition: transition,
       }
-    }, [dndActive]);
-    const sensors = useSensors(
-      useCustomPointerSensor(),
-      useCustomKeyboardSensor({ coordinateGetter: sortableKeyboardCoordinates })
-    );
-    return (
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragStart={({ active }) => {
-          if (dndActive !== null) return;
-          setDndActive(active);
-        }}
-        onDragOver={({ over }) => {
-          if (!over || !over.data.current) {
-            setInvHovering(false);
-            return;
-          }
-          if (!invHovering) {
-            setInvHovering(true);
-          }
-        }}
-        onDragEnd={({ active, over }) => {
-          if (dndActive && dndActive.data.current && dndActiveItem) {
-            if (
-              "inventory" in dndActive.data.current &&
-              over?.data.current &&
-              "sortable" in over.data.current
-            ) {
-              insert(over.data.current.sortable.index, {
-                value: dndActiveItem.value,
-                parameters: dndActiveItem.parameters as number[],
-              });
-            } else if (
-              "sortable" in dndActive.data.current &&
-              over?.data.current &&
-              "sortable" in over.data.current
-            ) {
-              move(
-                fields.findIndex((field) => field.id === active.id),
-                fields.findIndex((field) => field.id === over.id)
-              );
-            }
-          }
-          setTransformInvIds(genTransformInvIds());
-          setInvHovering(false);
-          setDndActive(null);
-        }}
-        onDragCancel={({ active }) => {
-          if (active.data.current && "inventory" in active.data.current) {
-            const index = fields.findIndex((field) => field.id === active.id);
-            if (index !== -1) {
-              remove(fields.findIndex((field) => field.id === active.id));
-            }
-          }
-          setTransformInvIds(genTransformInvIds());
-          setInvHovering(false);
-          setDndActive(null);
-        }}
+    : undefined;
+  return (
+    <div ref={setNodeRef}>
+      <Card
+        sx={{ p: 3 }}
+        style={{ ...{ display: "inline-block" }, ...style }}
+        {...attributes}
+        {...listeners}
       >
-        <Paper elevation={1} style={{ backgroundColor: "transparent" }}>
-          <Stack alignItems={"center"} spacing={2} padding={2}>
-            <Typography variant="h2" fontSize={25}>
+        <Stack
+          direction={"row"}
+          justifyContent={"space-between"}
+          alignItems={"center"}
+          spacing={3}
+        >
+          <HtmlTooltip
+            title={
+              <React.Fragment>
+                <Typography color="inherit">
+                  {STEP_SETTINGS.PARAMETERS.layers[data.value].label}
+                </Typography>
+                {STEP_SETTINGS.PARAMETERS.layers[data.value].description}
+              </React.Fragment>
+            }
+          >
+            <InfoIcon>Info</InfoIcon>
+          </HtmlTooltip>
+          <Typography variant="h3" fontSize={18}>
+            {STEP_SETTINGS.PARAMETERS.layers[data.value].label}
+          </Typography>
+          <Stack direction={"row"} alignItems={"center"} spacing={3}>
+            <Stack
+              direction={"row"}
+              alignItems={"center"}
+              justifyContent={"flex-end"}
+              spacing={2}
+              divider={<Divider orientation="vertical" flexItem />}
+            >
+              {STEP_SETTINGS.PARAMETERS.layers[data.value].parameters.map(
+                (parameter, index) => (
+                  <div key={index} data-no-dnd>
+                    {formProps ? (
+                      <Controller
+                        name={`layers.${formProps.index}.parameters.${index}`}
+                        control={formProps.control}
+                        rules={{ required: true }}
+                        render={({ field: { onChange, value } }) => (
+                          <TextField
+                            label={parameter.label}
+                            size={"small"}
+                            style={{ minWidth: "124px" }}
+                            type={parameter.type}
+                            onChange={onChange}
+                            value={value}
+                            required
+                            error={
+                              formProps.errors.layers?.[formProps.index]
+                                ?.parameters?.[index]
+                                ? true
+                                : false
+                            }
+                          />
+                        )}
+                      />
+                    ) : (
+                      <TextField
+                        label={parameter.label}
+                        size={"small"}
+                        type={parameter.type}
+                        value={""}
+                        required
+                      />
+                    )}
+                  </div>
+                )
+              )}
+            </Stack>
+            <div data-no-dnd>
+              <IconButton onClick={formProps?.remove}>
+                <DeleteIcon />
+              </IconButton>
+            </div>
+          </Stack>
+        </Stack>
+      </Card>
+    </div>
+  );
+};
+
+const LayerInventoryComponent = ({
+  id,
+  value,
+}: {
+  id: number;
+  value: (typeof STEP_SETTINGS.PARAMETERS.layerValues)[number];
+}) => {
+  const { attributes, listeners, isDragging, setNodeRef } = useDraggable({
+    id: id,
+    data: {
+      inventory: {
+        value,
+      },
+    },
+  });
+
+  const style = {
+    opacity: isDragging ? 0.4 : undefined,
+  };
+  return (
+    <div ref={setNodeRef}>
+      <Card
+        sx={{ p: 1 }}
+        style={{ ...{ display: "inline-block" }, ...style }}
+        {...attributes}
+        {...listeners}
+      >
+        {STEP_SETTINGS.PARAMETERS.layers[value].label}
+      </Card>
+    </div>
+  );
+};
+
+const TrainTransformsDnd = ({
+  control,
+  errors,
+}: {
+  control: Control<ParameterData, unknown>;
+  errors: FieldErrors<ParameterData>;
+}) => {
+  const { fields, move, insert, remove } = useFieldArray({
+    control: control,
+    name: "trainTransforms",
+  });
+  const genTransformInvIds = () =>
+    Object.fromEntries(
+      STEP_SETTINGS.PARAMETERS.transformValues.map((transformValue) => [
+        transformValue,
+        Math.floor(Math.random() * Date.now()),
+      ])
+    );
+  const [transformInvIds, setTransformInvIds] = useState<{
+    [transformValue: string]: number;
+  }>(genTransformInvIds());
+  const [dndActive, setDndActive] = useState<Active | null>(null);
+  const [invHovering, setInvHovering] = useState<boolean>(false);
+
+  const dndActiveItem = useMemo(() => {
+    if (!dndActive) return;
+    if (dndActive.data.current && "inventory" in dndActive.data.current) {
+      const value = dndActive.data.current.inventory
+        .value as (typeof STEP_SETTINGS.PARAMETERS.transformValues)[number];
+      return {
+        id: transformInvIds[value],
+        value: value,
+        parameters: STEP_SETTINGS.PARAMETERS.transforms[value].parameters.map(
+          () => ""
+        ) as ""[],
+      };
+    } else if (dndActive.data.current && "sortable" in dndActive.data.current) {
+      return fields[dndActive.data.current.sortable.index];
+    }
+  }, [dndActive]);
+  const sensors = useSensors(
+    useCustomPointerSensor(),
+    useCustomKeyboardSensor({ coordinateGetter: sortableKeyboardCoordinates })
+  );
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={({ active }) => {
+        if (dndActive !== null) return;
+        setDndActive(active);
+      }}
+      onDragOver={({ over }) => {
+        if (!over || !over.data.current) {
+          setInvHovering(false);
+          return;
+        }
+        if (!invHovering) {
+          setInvHovering(true);
+        }
+      }}
+      onDragEnd={({ active, over }) => {
+        if (dndActive && dndActive.data.current && dndActiveItem) {
+          if (
+            "inventory" in dndActive.data.current &&
+            over?.data.current &&
+            "sortable" in over.data.current
+          ) {
+            insert(over.data.current.sortable.index, {
+              value: dndActiveItem.value,
+              parameters: dndActiveItem.parameters as number[],
+            });
+          } else if (
+            "sortable" in dndActive.data.current &&
+            over?.data.current &&
+            "sortable" in over.data.current
+          ) {
+            move(
+              fields.findIndex((field) => field.id === active.id),
+              fields.findIndex((field) => field.id === over.id)
+            );
+          }
+        }
+        setTransformInvIds(genTransformInvIds());
+        setInvHovering(false);
+        setDndActive(null);
+      }}
+      onDragCancel={({ active }) => {
+        if (active.data.current && "inventory" in active.data.current) {
+          const index = fields.findIndex((field) => field.id === active.id);
+          if (index !== -1) {
+            remove(fields.findIndex((field) => field.id === active.id));
+          }
+        }
+        setTransformInvIds(genTransformInvIds());
+        setInvHovering(false);
+        setDndActive(null);
+      }}
+    >
+      <Paper elevation={1} style={{ backgroundColor: "transparent" }}>
+        <Stack alignItems={"center"} spacing={2} padding={2}>
+          <Typography variant="h2" fontSize={25}>
             Train Transforms
-            </Typography>
-            <Stack direction={"row"} spacing={2} justifyContent={"center"} sx={{ flexWrap: 'wrap', gap: 1 }}>
+          </Typography>
+          <Stack
+            direction={"row"}
+            spacing={2}
+            justifyContent={"center"}
+            sx={{ flexWrap: "wrap", gap: 1 }}
+          >
             {STEP_SETTINGS.PARAMETERS.transformValues.map((value) => (
               <TrainTransformInventoryComponent
-              id={transformInvIds[value]}
-              key={value}
-              value={value}
+                id={transformInvIds[value]}
+                key={value}
+                value={value}
               />
             ))}
-            </Stack>
           </Stack>
-        </Paper>
-        <Container>
-          <Stack spacing={0}>
-            <SortableContext
-              items={
+        </Stack>
+      </Paper>
+      <Container>
+        <Stack spacing={0}>
+          <SortableContext
+            items={
+              dndActiveItem &&
+              dndActive?.data.current &&
+              "inventory" in dndActive.data.current
+                ? [dndActiveItem, ...fields]
+                : fields
+            }
+            strategy={verticalListSortingStrategy}
+          >
+            {fields.length > 0 ? (
+              [
                 dndActiveItem &&
                 dndActive?.data.current &&
-                "inventory" in dndActive.data.current
-                  ? [dndActiveItem, ...fields]
-                  : fields
-              }
-              strategy={verticalListSortingStrategy}
-            >
-              {fields.length > 0 ? (
-                [
-                  dndActiveItem &&
-                  dndActive?.data.current &&
-                  "inventory" in dndActive.data.current &&
-                  invHovering ? (
-                    <TrainTransformComponent
-                      key={dndActiveItem.id}
-                      id={dndActiveItem.id}
-                      data={dndActiveItem as ParameterData["trainTransforms"][number]}
-                    />
-                  ) : null,
-                  ...fields.map((field, index) => (
-                    <TrainTransformComponent
-                      key={field.id}
-                      id={field.id}
-                      data={field}
-                      formProps={{
-                        index: index,
-                        control: control,
-                        errors: errors,
-                        remove: () => remove(index),
-                      }}
-                    />
-                  )),
-                ]
-              ) : (
-                <Card>This is Unimplemented</Card>
-              )}
-            </SortableContext>
-          </Stack>
-        </Container>
-  
-        <ClientOnlyPortal selector="#portal">
-          <DragOverlay style={{ width: undefined }}>
-            {dndActiveItem ? (
-              dndActive?.data.current && "sortable" in dndActive.data.current ? (
-                <TrainTransformComponent
-                  data={dndActiveItem as ParameterData["trainTransforms"][number]}
-                  formProps={{
-                    index: dndActive.data.current.sortable.index,
-                    control: control,
-                    errors: errors,
-                  }}
-                />
-              ) : (
-                <TrainTransformComponent
-                  data={dndActiveItem as ParameterData["trainTransforms"][number]}
-                />
-              )
-            ) : null}
-          </DragOverlay>
-        </ClientOnlyPortal>
-      </DndContext>
-    );
-  };
-  
-  const TrainTransformComponent = ({
-    id,
-    data,
-    formProps,
-  }: {
-    id?: string | number;
-    data: ParameterData["trainTransforms"][number];
-    formProps?: {
-      index: number;
-      control: Control<ParameterData, unknown>;
-      errors: FieldErrors<ParameterData>;
-      remove?: () => void;
-    };
-  }) => {
-    const {
-      attributes,
-      listeners,
-      setNodeRef,
-      isDragging,
-      transform,
-      transition,
-    } = id
-      ? useSortable({ id })
-      : {
-          attributes: undefined,
-          listeners: undefined,
-          setNodeRef: undefined,
-          isDragging: undefined,
-          transform: undefined,
-          transition: undefined,
-        };
-    const style = transform
-      ? {
-          opacity: isDragging ? 0.4 : undefined,
-          transform: CSS.Transform.toString(transform),
-          transition: transition,
-        }
-      : undefined;
-    return (
-      <div ref={setNodeRef}>
-        <Card
-          sx={{ p: 3 }}
-          style={{ ...{ display: "inline-block" }, ...style }}
-          {...attributes}
-          {...listeners}
-        >
-          <Stack
-            direction={"row"}
-            justifyContent={"space-between"}
-            alignItems={"center"}
-            spacing={3}
-          >
-            <Typography variant="h3" fontSize={18}>
-              {STEP_SETTINGS.PARAMETERS.transforms[data.value].label}
-            </Typography>
-            <Stack direction={"row"} alignItems={"center"} spacing={3}>
-              <Stack
-                direction={"row"}
-                alignItems={"center"}
-                justifyContent={"flex-end"}
-                spacing={2}
-                divider={<Divider orientation="vertical" flexItem />}
-              >
-                {STEP_SETTINGS.PARAMETERS.transforms[data.value].parameters.map(
-                  (parameter, index) => (
-                    <div key={index} data-no-dnd>
-                      {formProps ? (
-                        <Controller
-                          name={`trainTransforms.${formProps.index}.parameters.${index}`}
-                          control={formProps.control}
-                          rules={{ required: true }}
-                          render={({ field: { onChange, value } }) => (
-                            <TextField
-                              label={parameter.label}
-                              size={"small"}
-                              type={parameter.type}
-                              onChange={onChange}
-                              value={value}
-                              required
-                              error={
-                                formProps.errors.trainTransforms?.[formProps.index]
-                                  ?.parameters?.[index]
-                                  ? true
-                                  : false
-                              }
-                            />
-                          )}
-                        />
-                      ) : (
-                        <TextField
-                          label={parameter.label}
-                          size={"small"}
-                          type={parameter.type}
-                          value={""}
-                          required
-                        />
-                      )}
-                    </div>
-                  )
-                )}
-              </Stack>
-              <div data-no-dnd>
-                <IconButton onClick={formProps?.remove}>
-                  <DeleteIcon />
-                </IconButton>
-              </div>
-            </Stack>
-          </Stack>
-        </Card>
-      </div>
-    );
-  };
-  
-  const TrainTransformInventoryComponent = ({
-    id,
-    value,
-  }: {
-    id: number;
-    value: (typeof STEP_SETTINGS.PARAMETERS.transformValues)[number];
-  }) => {
-    const { attributes, listeners, isDragging, setNodeRef } = useDraggable({
-      id: id,
-      data: {
-        inventory: {
-          value,
-        },
-      },
-    });
-  
-    const style = {
-      opacity: isDragging ? 0.4 : undefined,
-    };
-    return (
-      <div ref={setNodeRef}>
-        <Card
-          sx={{ p: 1 }}
-          style={{ ...{ display: "inline-block" }, ...style }}
-          {...attributes}
-          {...listeners}
-        >
-          {STEP_SETTINGS.PARAMETERS.transforms[value].label}
-        </Card>
-      </div>
-    );
-  };
+                "inventory" in dndActive.data.current &&
+                invHovering ? (
+                  <TrainTransformComponent
+                    key={dndActiveItem.id}
+                    id={dndActiveItem.id}
+                    data={
+                      dndActiveItem as ParameterData["trainTransforms"][number]
+                    }
+                  />
+                ) : null,
+                ...fields.map((field, index) => (
+                  <TrainTransformComponent
+                    key={field.id}
+                    id={field.id}
+                    data={field}
+                    formProps={{
+                      index: index,
+                      control: control,
+                      errors: errors,
+                      remove: () => remove(index),
+                    }}
+                  />
+                )),
+              ]
+            ) : (
+              <Card>This is Unimplemented</Card>
+            )}
+          </SortableContext>
+        </Stack>
+      </Container>
 
-  const TestTransformsDnd = ({
-    control,
-    errors,
-  }: {
+      <ClientOnlyPortal selector="#portal">
+        <DragOverlay style={{ width: undefined }}>
+          {dndActiveItem ? (
+            dndActive?.data.current && "sortable" in dndActive.data.current ? (
+              <TrainTransformComponent
+                data={dndActiveItem as ParameterData["trainTransforms"][number]}
+                formProps={{
+                  index: dndActive.data.current.sortable.index,
+                  control: control,
+                  errors: errors,
+                }}
+              />
+            ) : (
+              <TrainTransformComponent
+                data={dndActiveItem as ParameterData["trainTransforms"][number]}
+              />
+            )
+          ) : null}
+        </DragOverlay>
+      </ClientOnlyPortal>
+    </DndContext>
+  );
+};
+
+const TrainTransformComponent = ({
+  id,
+  data,
+  formProps,
+}: {
+  id?: string | number;
+  data: ParameterData["trainTransforms"][number];
+  formProps?: {
+    index: number;
     control: Control<ParameterData, unknown>;
     errors: FieldErrors<ParameterData>;
-  }) => {
-    const { fields, move, insert, remove } = useFieldArray({
-      control: control,
-      name: "testTransforms",
-    });
-    const genTransformInvIds = () =>
-      Object.fromEntries(
-        STEP_SETTINGS.PARAMETERS.transformValues.map((transformValue) => [
-          transformValue,
-          Math.floor(Math.random() * Date.now()),
-        ])
-      );
-    const [transformInvIds, setTransformInvIds] = useState<{
-      [transformValue: string]: number;
-    }>(genTransformInvIds());
-    const [dndActive, setDndActive] = useState<Active | null>(null);
-    const [invHovering, setInvHovering] = useState<boolean>(false);
-  
-    const dndActiveItem = useMemo(() => {
-      if (!dndActive) return;
-      if (dndActive.data.current && "inventory" in dndActive.data.current) {
-        const value = dndActive.data.current.inventory
-          .value as (typeof STEP_SETTINGS.PARAMETERS.transformValues)[number];
-        return {
-          id: transformInvIds[value],
-          value: value,
-          parameters: STEP_SETTINGS.PARAMETERS.transforms[value].parameters.map(
-            () => ""
-          ) as ""[],
-        };
-      } else if (dndActive.data.current && "sortable" in dndActive.data.current) {
-        return fields[dndActive.data.current.sortable.index];
-      }
-    }, [dndActive]);
-    const sensors = useSensors(
-      useCustomPointerSensor(),
-      useCustomKeyboardSensor({ coordinateGetter: sortableKeyboardCoordinates })
-    );
-    return (
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragStart={({ active }) => {
-          if (dndActive !== null) return;
-          setDndActive(active);
-        }}
-        onDragOver={({ over }) => {
-          if (!over || !over.data.current) {
-            setInvHovering(false);
-            return;
-          }
-          if (!invHovering) {
-            setInvHovering(true);
-          }
-        }}
-        onDragEnd={({ active, over }) => {
-          if (dndActive && dndActive.data.current && dndActiveItem) {
-            if (
-              "inventory" in dndActive.data.current &&
-              over?.data.current &&
-              "sortable" in over.data.current
-            ) {
-              insert(over.data.current.sortable.index, {
-                value: dndActiveItem.value,
-                parameters: dndActiveItem.parameters as number[],
-              });
-            } else if (
-              "sortable" in dndActive.data.current &&
-              over?.data.current &&
-              "sortable" in over.data.current
-            ) {
-              move(
-                fields.findIndex((field) => field.id === active.id),
-                fields.findIndex((field) => field.id === over.id)
-              );
-            }
-          }
-          setTransformInvIds(genTransformInvIds());
-          setInvHovering(false);
-          setDndActive(null);
-        }}
-        onDragCancel={({ active }) => {
-          if (active.data.current && "inventory" in active.data.current) {
-            const index = fields.findIndex((field) => field.id === active.id);
-            if (index !== -1) {
-              remove(fields.findIndex((field) => field.id === active.id));
-            }
-          }
-          setTransformInvIds(genTransformInvIds());
-          setInvHovering(false);
-          setDndActive(null);
-        }}
-      >
-        <Paper elevation={1} style={{ backgroundColor: "transparent" }}>
-          <Stack alignItems={"center"} spacing={2} padding={2}>
-            <Typography variant="h2" fontSize={25}>
-            Test Transforms
-            </Typography>
-            <Stack direction={"row"} spacing={2} justifyContent={"center"} sx={{ flexWrap: 'wrap', gap: 1 }}>
-            {STEP_SETTINGS.PARAMETERS.transformValues.map((value) => (
-              <TestTransformInventoryComponent
-              id={transformInvIds[value]}
-              key={value}
-              value={value}
-              />
-            ))}
-            </Stack>
-          </Stack>
-        </Paper>
-        <Container>
-          <Stack spacing={0}>
-            <SortableContext
-              items={
-                dndActiveItem &&
-                dndActive?.data.current &&
-                "inventory" in dndActive.data.current
-                  ? [dndActiveItem, ...fields]
-                  : fields
-              }
-              strategy={verticalListSortingStrategy}
-            >
-              {fields.length > 0 ? (
-                [
-                  dndActiveItem &&
-                  dndActive?.data.current &&
-                  "inventory" in dndActive.data.current &&
-                  invHovering ? (
-                    <TestTransformComponent
-                      key={dndActiveItem.id}
-                      id={dndActiveItem.id}
-                      data={dndActiveItem as ParameterData["testTransforms"][number]}
-                    />
-                  ) : null,
-                  ...fields.map((field, index) => (
-                    <TestTransformComponent
-                      key={field.id}
-                      id={field.id}
-                      data={field}
-                      formProps={{
-                        index: index,
-                        control: control,
-                        errors: errors,
-                        remove: () => remove(index),
-                      }}
-                    />
-                  )),
-                ]
-              ) : (
-                <Card>This is Unimplemented</Card>
-              )}
-            </SortableContext>
-          </Stack>
-        </Container>
-  
-        <ClientOnlyPortal selector="#portal">
-          <DragOverlay style={{ width: undefined }}>
-            {dndActiveItem ? (
-              dndActive?.data.current && "sortable" in dndActive.data.current ? (
-                <TestTransformComponent
-                  data={dndActiveItem as ParameterData["testTransforms"][number]}
-                  formProps={{
-                    index: dndActive.data.current.sortable.index,
-                    control: control,
-                    errors: errors,
-                  }}
-                />
-              ) : (
-                <TestTransformComponent
-                  data={dndActiveItem as ParameterData["testTransforms"][number]}
-                />
-              )
-            ) : null}
-          </DragOverlay>
-        </ClientOnlyPortal>
-      </DndContext>
-    );
+    remove?: () => void;
   };
-  
-  const TestTransformComponent = ({
-    id,
-    data,
-    formProps,
-  }: {
-    id?: string | number;
-    data: ParameterData["testTransforms"][number];
-    formProps?: {
-      index: number;
-      control: Control<ParameterData, unknown>;
-      errors: FieldErrors<ParameterData>;
-      remove?: () => void;
-    };
-  }) => {
-    const {
-      attributes,
-      listeners,
-      setNodeRef,
-      isDragging,
-      transform,
-      transition,
-    } = id
-      ? useSortable({ id })
-      : {
-          attributes: undefined,
-          listeners: undefined,
-          setNodeRef: undefined,
-          isDragging: undefined,
-          transform: undefined,
-          transition: undefined,
-        };
-    const style = transform
-      ? {
-          opacity: isDragging ? 0.4 : undefined,
-          transform: CSS.Transform.toString(transform),
-          transition: transition,
-        }
-      : undefined;
-    return (
-      <div ref={setNodeRef}>
-        <Card
-          sx={{ p: 3 }}
-          style={{ ...{ display: "inline-block" }, ...style }}
-          {...attributes}
-          {...listeners}
+}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    isDragging,
+    transform,
+    transition,
+  } = id
+    ? useSortable({ id })
+    : {
+        attributes: undefined,
+        listeners: undefined,
+        setNodeRef: undefined,
+        isDragging: undefined,
+        transform: undefined,
+        transition: undefined,
+      };
+  const style = transform
+    ? {
+        opacity: isDragging ? 0.4 : undefined,
+        transform: CSS.Transform.toString(transform),
+        transition: transition,
+      }
+    : undefined;
+  return (
+    <div ref={setNodeRef}>
+      <Card
+        sx={{ p: 3 }}
+        style={{ ...{ display: "inline-block" }, ...style }}
+        {...attributes}
+        {...listeners}
+      >
+        <Stack
+          direction={"row"}
+          justifyContent={"space-between"}
+          alignItems={"center"}
+          spacing={3}
         >
+          <Typography variant="h3" fontSize={18}>
+            {STEP_SETTINGS.PARAMETERS.transforms[data.value].label}
+          </Typography>
+          <Stack direction={"row"} alignItems={"center"} spacing={3}>
+            <Stack
+              direction={"row"}
+              alignItems={"center"}
+              justifyContent={"flex-end"}
+              spacing={2}
+              divider={<Divider orientation="vertical" flexItem />}
+            >
+              {STEP_SETTINGS.PARAMETERS.transforms[data.value].parameters.map(
+                (parameter, index) => (
+                  <div key={index} data-no-dnd>
+                    {formProps ? (
+                      <Controller
+                        name={`trainTransforms.${formProps.index}.parameters.${index}`}
+                        control={formProps.control}
+                        rules={{ required: true }}
+                        render={({ field: { onChange, value } }) => (
+                          <TextField
+                            label={parameter.label}
+                            size={"small"}
+                            type={parameter.type}
+                            onChange={onChange}
+                            value={value}
+                            required
+                            error={
+                              formProps.errors.trainTransforms?.[
+                                formProps.index
+                              ]?.parameters?.[index]
+                                ? true
+                                : false
+                            }
+                          />
+                        )}
+                      />
+                    ) : (
+                      <TextField
+                        label={parameter.label}
+                        size={"small"}
+                        type={parameter.type}
+                        value={""}
+                        required
+                      />
+                    )}
+                  </div>
+                )
+              )}
+            </Stack>
+            <div data-no-dnd>
+              <IconButton onClick={formProps?.remove}>
+                <DeleteIcon />
+              </IconButton>
+            </div>
+          </Stack>
+        </Stack>
+      </Card>
+    </div>
+  );
+};
+
+const TrainTransformInventoryComponent = ({
+  id,
+  value,
+}: {
+  id: number;
+  value: (typeof STEP_SETTINGS.PARAMETERS.transformValues)[number];
+}) => {
+  const { attributes, listeners, isDragging, setNodeRef } = useDraggable({
+    id: id,
+    data: {
+      inventory: {
+        value,
+      },
+    },
+  });
+
+  const style = {
+    opacity: isDragging ? 0.4 : undefined,
+  };
+  return (
+    <div ref={setNodeRef}>
+      <Card
+        sx={{ p: 1 }}
+        style={{ ...{ display: "inline-block" }, ...style }}
+        {...attributes}
+        {...listeners}
+      >
+        {STEP_SETTINGS.PARAMETERS.transforms[value].label}
+      </Card>
+    </div>
+  );
+};
+
+const TestTransformsDnd = ({
+  control,
+  errors,
+}: {
+  control: Control<ParameterData, unknown>;
+  errors: FieldErrors<ParameterData>;
+}) => {
+  const { fields, move, insert, remove } = useFieldArray({
+    control: control,
+    name: "testTransforms",
+  });
+  const genTransformInvIds = () =>
+    Object.fromEntries(
+      STEP_SETTINGS.PARAMETERS.transformValues.map((transformValue) => [
+        transformValue,
+        Math.floor(Math.random() * Date.now()),
+      ])
+    );
+  const [transformInvIds, setTransformInvIds] = useState<{
+    [transformValue: string]: number;
+  }>(genTransformInvIds());
+  const [dndActive, setDndActive] = useState<Active | null>(null);
+  const [invHovering, setInvHovering] = useState<boolean>(false);
+
+  const dndActiveItem = useMemo(() => {
+    if (!dndActive) return;
+    if (dndActive.data.current && "inventory" in dndActive.data.current) {
+      const value = dndActive.data.current.inventory
+        .value as (typeof STEP_SETTINGS.PARAMETERS.transformValues)[number];
+      return {
+        id: transformInvIds[value],
+        value: value,
+        parameters: STEP_SETTINGS.PARAMETERS.transforms[value].parameters.map(
+          () => ""
+        ) as ""[],
+      };
+    } else if (dndActive.data.current && "sortable" in dndActive.data.current) {
+      return fields[dndActive.data.current.sortable.index];
+    }
+  }, [dndActive]);
+  const sensors = useSensors(
+    useCustomPointerSensor(),
+    useCustomKeyboardSensor({ coordinateGetter: sortableKeyboardCoordinates })
+  );
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={({ active }) => {
+        if (dndActive !== null) return;
+        setDndActive(active);
+      }}
+      onDragOver={({ over }) => {
+        if (!over || !over.data.current) {
+          setInvHovering(false);
+          return;
+        }
+        if (!invHovering) {
+          setInvHovering(true);
+        }
+      }}
+      onDragEnd={({ active, over }) => {
+        if (dndActive && dndActive.data.current && dndActiveItem) {
+          if (
+            "inventory" in dndActive.data.current &&
+            over?.data.current &&
+            "sortable" in over.data.current
+          ) {
+            insert(over.data.current.sortable.index, {
+              value: dndActiveItem.value,
+              parameters: dndActiveItem.parameters as number[],
+            });
+          } else if (
+            "sortable" in dndActive.data.current &&
+            over?.data.current &&
+            "sortable" in over.data.current
+          ) {
+            move(
+              fields.findIndex((field) => field.id === active.id),
+              fields.findIndex((field) => field.id === over.id)
+            );
+          }
+        }
+        setTransformInvIds(genTransformInvIds());
+        setInvHovering(false);
+        setDndActive(null);
+      }}
+      onDragCancel={({ active }) => {
+        if (active.data.current && "inventory" in active.data.current) {
+          const index = fields.findIndex((field) => field.id === active.id);
+          if (index !== -1) {
+            remove(fields.findIndex((field) => field.id === active.id));
+          }
+        }
+        setTransformInvIds(genTransformInvIds());
+        setInvHovering(false);
+        setDndActive(null);
+      }}
+    >
+      <Paper elevation={1} style={{ backgroundColor: "transparent" }}>
+        <Stack alignItems={"center"} spacing={2} padding={2}>
+          <Typography variant="h2" fontSize={25}>
+            Test Transforms
+          </Typography>
           <Stack
             direction={"row"}
-            justifyContent={"space-between"}
-            alignItems={"center"}
-            spacing={3}
+            spacing={2}
+            justifyContent={"center"}
+            sx={{ flexWrap: "wrap", gap: 1 }}
           >
-            <Typography variant="h3" fontSize={18}>
-              {STEP_SETTINGS.PARAMETERS.transforms[data.value].label}
-            </Typography>
-            <Stack direction={"row"} alignItems={"center"} spacing={3}>
-              <Stack
-                direction={"row"}
-                alignItems={"center"}
-                justifyContent={"flex-end"}
-                spacing={2}
-                divider={<Divider orientation="vertical" flexItem />}
-              >
-                {STEP_SETTINGS.PARAMETERS.transforms[data.value].parameters.map(
-                  (parameter, index) => (
-                    <div key={index} data-no-dnd>
-                      {formProps ? (
-                        <Controller
-                          name={`testTransforms.${formProps.index}.parameters.${index}`}
-                          control={formProps.control}
-                          rules={{ required: true }}
-                          render={({ field: { onChange, value } }) => (
-                            <TextField
-                              label={parameter.label}
-                              size={"small"}
-                              type={parameter.type}
-                              onChange={onChange}
-                              value={value}
-                              required
-                              error={
-                                formProps.errors.testTransforms?.[formProps.index]
-                                  ?.parameters?.[index]
-                                  ? true
-                                  : false
-                              }
-                            />
-                          )}
-                        />
-                      ) : (
-                        <TextField
-                          label={parameter.label}
-                          size={"small"}
-                          type={parameter.type}
-                          value={""}
-                          required
-                        />
-                      )}
-                    </div>
-                  )
-                )}
-              </Stack>
-              <div data-no-dnd>
-                <IconButton onClick={formProps?.remove}>
-                  <DeleteIcon />
-                </IconButton>
-              </div>
-            </Stack>
+            {STEP_SETTINGS.PARAMETERS.transformValues.map((value) => (
+              <TestTransformInventoryComponent
+                id={transformInvIds[value]}
+                key={value}
+                value={value}
+              />
+            ))}
           </Stack>
-        </Card>
-      </div>
-    );
+        </Stack>
+      </Paper>
+      <Container>
+        <Stack spacing={0}>
+          <SortableContext
+            items={
+              dndActiveItem &&
+              dndActive?.data.current &&
+              "inventory" in dndActive.data.current
+                ? [dndActiveItem, ...fields]
+                : fields
+            }
+            strategy={verticalListSortingStrategy}
+          >
+            {fields.length > 0 ? (
+              [
+                dndActiveItem &&
+                dndActive?.data.current &&
+                "inventory" in dndActive.data.current &&
+                invHovering ? (
+                  <TestTransformComponent
+                    key={dndActiveItem.id}
+                    id={dndActiveItem.id}
+                    data={
+                      dndActiveItem as ParameterData["testTransforms"][number]
+                    }
+                  />
+                ) : null,
+                ...fields.map((field, index) => (
+                  <TestTransformComponent
+                    key={field.id}
+                    id={field.id}
+                    data={field}
+                    formProps={{
+                      index: index,
+                      control: control,
+                      errors: errors,
+                      remove: () => remove(index),
+                    }}
+                  />
+                )),
+              ]
+            ) : (
+              <Card>This is Unimplemented</Card>
+            )}
+          </SortableContext>
+        </Stack>
+      </Container>
+
+      <ClientOnlyPortal selector="#portal">
+        <DragOverlay style={{ width: undefined }}>
+          {dndActiveItem ? (
+            dndActive?.data.current && "sortable" in dndActive.data.current ? (
+              <TestTransformComponent
+                data={dndActiveItem as ParameterData["testTransforms"][number]}
+                formProps={{
+                  index: dndActive.data.current.sortable.index,
+                  control: control,
+                  errors: errors,
+                }}
+              />
+            ) : (
+              <TestTransformComponent
+                data={dndActiveItem as ParameterData["testTransforms"][number]}
+              />
+            )
+          ) : null}
+        </DragOverlay>
+      </ClientOnlyPortal>
+    </DndContext>
+  );
+};
+
+const TestTransformComponent = ({
+  id,
+  data,
+  formProps,
+}: {
+  id?: string | number;
+  data: ParameterData["testTransforms"][number];
+  formProps?: {
+    index: number;
+    control: Control<ParameterData, unknown>;
+    errors: FieldErrors<ParameterData>;
+    remove?: () => void;
   };
-  
-  const TestTransformInventoryComponent = ({
-    id,
-    value,
-  }: {
-    id: number;
-    value: (typeof STEP_SETTINGS.PARAMETERS.transformValues)[number];
-  }) => {
-    const { attributes, listeners, isDragging, setNodeRef } = useDraggable({
-      id: id,
-      data: {
-        inventory: {
-          value,
-        },
-      },
-    });
-  
-    const style = {
-      opacity: isDragging ? 0.4 : undefined,
-    };
-    return (
-      <div ref={setNodeRef}>
-        <Card
-          sx={{ p: 1 }}
-          style={{ ...{ display: "inline-block" }, ...style }}
-          {...attributes}
-          {...listeners}
+}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    isDragging,
+    transform,
+    transition,
+  } = id
+    ? useSortable({ id })
+    : {
+        attributes: undefined,
+        listeners: undefined,
+        setNodeRef: undefined,
+        isDragging: undefined,
+        transform: undefined,
+        transition: undefined,
+      };
+  const style = transform
+    ? {
+        opacity: isDragging ? 0.4 : undefined,
+        transform: CSS.Transform.toString(transform),
+        transition: transition,
+      }
+    : undefined;
+  return (
+    <div ref={setNodeRef}>
+      <Card
+        sx={{ p: 3 }}
+        style={{ ...{ display: "inline-block" }, ...style }}
+        {...attributes}
+        {...listeners}
+      >
+        <Stack
+          direction={"row"}
+          justifyContent={"space-between"}
+          alignItems={"center"}
+          spacing={3}
         >
-          {STEP_SETTINGS.PARAMETERS.transforms[value].label}
-        </Card>
-      </div>
-    );
+          <Typography variant="h3" fontSize={18}>
+            {STEP_SETTINGS.PARAMETERS.transforms[data.value].label}
+          </Typography>
+          <Stack direction={"row"} alignItems={"center"} spacing={3}>
+            <Stack
+              direction={"row"}
+              alignItems={"center"}
+              justifyContent={"flex-end"}
+              spacing={2}
+              divider={<Divider orientation="vertical" flexItem />}
+            >
+              {STEP_SETTINGS.PARAMETERS.transforms[data.value].parameters.map(
+                (parameter, index) => (
+                  <div key={index} data-no-dnd>
+                    {formProps ? (
+                      <Controller
+                        name={`testTransforms.${formProps.index}.parameters.${index}`}
+                        control={formProps.control}
+                        rules={{ required: true }}
+                        render={({ field: { onChange, value } }) => (
+                          <TextField
+                            label={parameter.label}
+                            size={"small"}
+                            type={parameter.type}
+                            onChange={onChange}
+                            value={value}
+                            required
+                            error={
+                              formProps.errors.testTransforms?.[formProps.index]
+                                ?.parameters?.[index]
+                                ? true
+                                : false
+                            }
+                          />
+                        )}
+                      />
+                    ) : (
+                      <TextField
+                        label={parameter.label}
+                        size={"small"}
+                        type={parameter.type}
+                        value={""}
+                        required
+                      />
+                    )}
+                  </div>
+                )
+              )}
+            </Stack>
+            <div data-no-dnd>
+              <IconButton onClick={formProps?.remove}>
+                <DeleteIcon />
+              </IconButton>
+            </div>
+          </Stack>
+        </Stack>
+      </Card>
+    </div>
+  );
+};
+
+const TestTransformInventoryComponent = ({
+  id,
+  value,
+}: {
+  id: number;
+  value: (typeof STEP_SETTINGS.PARAMETERS.transformValues)[number];
+}) => {
+  const { attributes, listeners, isDragging, setNodeRef } = useDraggable({
+    id: id,
+    data: {
+      inventory: {
+        value,
+      },
+    },
+  });
+
+  const style = {
+    opacity: isDragging ? 0.4 : undefined,
   };
+  return (
+    <div ref={setNodeRef}>
+      <Card
+        sx={{ p: 1 }}
+        style={{ ...{ display: "inline-block" }, ...style }}
+        {...attributes}
+        {...listeners}
+      >
+        {STEP_SETTINGS.PARAMETERS.transforms[value].label}
+      </Card>
+    </div>
+  );
+};
 
 export default ImageParametersStep;

--- a/frontend/src/features/Train/features/Image/components/ImageParametersStep.tsx
+++ b/frontend/src/features/Train/features/Image/components/ImageParametersStep.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useGetColumnsFromDatasetQuery } from "@/features/Train/redux/trainspaceApi";
 import { useAppDispatch, useAppSelector } from "@/common/redux/hooks";
+import { styled } from "@mui/material/styles";
+import Tooltip, { tooltipClasses } from "@mui/material/Tooltip";
+import InfoIcon from "@mui/icons-material/Info";
+
 import {
   Autocomplete,
   Card,
@@ -52,6 +56,34 @@ import {
 } from "@/common/utils/dndHelpers";
 import ClientOnlyPortal from "@/common/components/ClientOnlyPortal";
 import { updateImageTrainspaceData } from "../redux/imageActions";
+
+
+
+const HtmlTooltip = styled(
+  ({
+    className,
+    title,
+    children,
+    ...props
+  }: {
+    className?: string;
+    children: React.ReactElement;
+    title: React.ReactNode;
+  }) => (
+    <Tooltip title={title} {...props} classes={{ popper: className }}>
+      {children}
+    </Tooltip>
+  )
+)(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: "rgba(255, 255, 255, 0.95)",
+    color: "rgba(0, 0, 0, 0.87)",
+    maxWidth: 220,
+    fontSize: theme.typography.pxToRem(12),
+    border: "none",
+  },
+}));
+
 
 const ImageParametersStep = ({
     renderStepperButtons,
@@ -463,13 +495,24 @@ const ImageParametersStep = ({
             alignItems={"center"}
             spacing={3}
           >
+            <HtmlTooltip
+              title={
+                <React.Fragment>
+                  <Typography color="inherit">
+                    {STEP_SETTINGS.PARAMETERS.layers[data.value].label}
+                  </Typography>
+                  {STEP_SETTINGS.PARAMETERS.layers[data.value].description}
+                </React.Fragment>
+              }
+            >
+              <InfoIcon>Info</InfoIcon>
+            </HtmlTooltip>
+
+
             <Typography variant="h3" fontSize={18}>
               {STEP_SETTINGS.PARAMETERS.layers[data.value].label}
             </Typography>
-            <Stack direction={"row"} 
-              alignItems={"center"} 
-              spacing={3} 
-            >
+            <Stack direction={"row"} alignItems={"center"} spacing={3}>
               <Stack
                 direction={"row"}
                 alignItems={"center"}

--- a/frontend/src/features/Train/features/Image/constants/imageConstants.ts
+++ b/frontend/src/features/Train/features/Image/constants/imageConstants.ts
@@ -82,6 +82,7 @@ export const STEP_SETTINGS = {
             type: "number",
           },
         ],
+        description: "The `CONV2d` function applies a filter to input data in a sliding window manner. By performing element-wise multiplication and sum of the overlapping portions, it captures local spatial patterns and features, enabling applications such as image recognition, object detection, and semantic segmentation in computer vision tasks.",
       },
       MAXPOOL2D: {
         label: "MaxPool2d",
@@ -102,6 +103,7 @@ export const STEP_SETTINGS = {
             type: "number",
           },
         ],
+        description: "MaxPool2d function reduces the size of input data by dividing it into non-overlapping rectangular regions and selecting the maximum value from each region. This downsampling operation preserves important features while decreasing spatial dimensions, making it beneficial for tasks like image classification and extracting spatial characteristics."
       },
       FLATTEN: {
         label: "Flatten",
@@ -122,6 +124,7 @@ export const STEP_SETTINGS = {
             type: "number",
           },
         ],
+        description: "The flatten operation takes a two-dimensional image representation and transforms it into a one-dimensional vector. This process unravels the image structure by concatenating the rows or columns of pixels, creating a linear sequence of values. By doing so, it allows the network to process the image as a simple list of numbers, facilitating tasks such as image classification or object detection in neural networks."
       },
       LINEAR: {
         label: "Linear",
@@ -142,11 +145,13 @@ export const STEP_SETTINGS = {
             type: "number",
           },
         ],
+        description: "A linear layer in an image dataset takes the flattened image representation and applies a learned linear transformation to map the input values to a new set of values, allowing the network to learn complex relationships for tasks like image classification or object recognition."
       },
       SIGMOID: {
         label: "Sigmoid",
         objectName: "nn.Sigmoid",
         parameters: [],
+        description: "The sigmoid function takes the input values, typically the output of a linear layer, and applies a mathematical function that compresses them into a range between 0 and 1. This transformation is useful for interpreting the output as probabilities, where values closer to 1 indicate higher confidence in the presence of a particular feature or class in the image."
       },
     },
     transformValues: ["GAUSSIAN_BLUR", "GRAYSCALE", "NORMALIZE", "RANDOM_HORIZONTAL_FLIP", "RANDOM_VERTICAL_FLIP", "RESIZE", "TO_TENSOR"],

--- a/frontend/src/features/Train/features/Tabular/components/TabularParametersStep.tsx
+++ b/frontend/src/features/Train/features/Tabular/components/TabularParametersStep.tsx
@@ -20,7 +20,13 @@ import {
   Switch,
   TextField,
   Typography,
+  TooltipProps,
+  TooltipClasses,
+  Button,
 } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import Tooltip, { tooltipClasses } from "@mui/material/Tooltip";
+import InfoIcon from "@mui/icons-material/Info";
 import {
   Control,
   Controller,
@@ -53,6 +59,31 @@ import {
 import ClientOnlyPortal from "@/common/components/ClientOnlyPortal";
 import { updateTabularTrainspaceData } from "../redux/tabularActions";
 
+const HtmlTooltip = styled(
+  ({
+    className,
+    title,
+    children,
+    ...props
+  }: {
+    className?: string;
+    children: React.ReactElement;
+    title: React.ReactNode;
+  }) => (
+    <Tooltip title={title} {...props} classes={{ popper: className }}>
+      {children}
+    </Tooltip>
+  )
+)(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: "rgba(255, 255, 255, 0.95)",
+    color: "rgba(0, 0, 0, 0.87)",
+    maxWidth: 220,
+    fontSize: theme.typography.pxToRem(12),
+    border: "none",
+  },
+}));
+
 const TabularParametersStep = ({
   renderStepperButtons,
   setIsModified,
@@ -77,7 +108,7 @@ const TabularParametersStep = ({
     handleSubmit,
     formState: { errors, isDirty },
     control,
-    watch
+    watch,
   } = useForm<ParameterData>({
     defaultValues: {
       targetCol:
@@ -141,7 +172,7 @@ const TabularParametersStep = ({
                 error={errors.targetCol ? true : false}
               />
             )}
-            options={data.filter(col => !features.includes(col))}
+            options={data.filter((col) => !features.includes(col))}
           />
         )}
       />
@@ -167,8 +198,7 @@ const TabularParametersStep = ({
                 error={errors.features ? true : false}
               />
             )}
-            
-            options={data.filter(col => col!== targetCol)}
+            options={data.filter((col) => col !== targetCol)}
           />
         )}
       />
@@ -535,6 +565,19 @@ const LayerComponent = ({
           alignItems={"center"}
           spacing={3}
         >
+          <HtmlTooltip
+            title={
+              <React.Fragment>
+                <Typography color="inherit">
+                  {STEP_SETTINGS.PARAMETERS.layers[data.value].label}
+                </Typography>
+                {STEP_SETTINGS.PARAMETERS.layers[data.value].description}
+              </React.Fragment>
+            }
+          >
+            <InfoIcon>Info</InfoIcon>
+          </HtmlTooltip>
+
           <Typography variant="h3" fontSize={18}>
             {STEP_SETTINGS.PARAMETERS.layers[data.value].label}
           </Typography>

--- a/frontend/src/features/Train/features/Tabular/components/TabularParametersStep.tsx
+++ b/frontend/src/features/Train/features/Tabular/components/TabularParametersStep.tsx
@@ -20,9 +20,6 @@ import {
   Switch,
   TextField,
   Typography,
-  TooltipProps,
-  TooltipClasses,
-  Button,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import Tooltip, { tooltipClasses } from "@mui/material/Tooltip";

--- a/frontend/src/features/Train/features/Tabular/constants/tabularConstants.ts
+++ b/frontend/src/features/Train/features/Tabular/constants/tabularConstants.ts
@@ -1,9 +1,3 @@
-
-import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import Button from '@mui/material/Button';
-import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
 import TabularDatasetStep from "../components/TabularDatasetStep";
 import TabularParametersStep from "../components/TabularParametersStep";
 import TabularReviewStep from "../components/TabularReviewStep";

--- a/frontend/src/features/Train/features/Tabular/constants/tabularConstants.ts
+++ b/frontend/src/features/Train/features/Tabular/constants/tabularConstants.ts
@@ -1,3 +1,9 @@
+
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import TabularDatasetStep from "../components/TabularDatasetStep";
 import TabularParametersStep from "../components/TabularParametersStep";
 import TabularReviewStep from "../components/TabularReviewStep";
@@ -61,6 +67,7 @@ export const STEP_SETTINGS = {
       { label: "Adam Optimization", value: "Adam" },
     ],
     layerValues: ["LINEAR", "RELU", "TANH", "SOFTMAX", "SIGMOID", "LOGSOFTMAX"],
+
     layers: {
       LINEAR: {
         label: "Linear",
@@ -81,16 +88,19 @@ export const STEP_SETTINGS = {
             type: "number",
           },
         ],
+        description: "A linear layer performs a mathematical operation called linear transformation on a set of input values. It applies a combination of scaling and shifting to the input values, resulting in a new set of transformed values as output."
       },
       RELU: {
         label: "ReLU",
         objectName: "nn.ReLU",
         parameters: [],
+        description: "ReLU, short for Rectified Linear Unit, is an activation function that acts like a filter that selectively allows positive numbers to pass through unchanged, while converting negative numbers to zero."
       },
       TANH: {
         label: "Tanh",
         objectName: "nn.Tanh",
         parameters: [],
+        description: "The tanh function maps input numbers to a range between -1 and 1, emphasizing values close to zero while diminishing the impact of extremely large or small numbers, making it useful for capturing complex patterns in data."
       },
       SOFTMAX: {
         label: "Softmax",
@@ -104,11 +114,13 @@ export const STEP_SETTINGS = {
             type: "number",
           },
         ],
+        description: "The softmax function takes a set of numbers as input and converts them into a probability distribution, assigning higher probabilities to larger numbers and lower probabilities to smaller numbers, making it useful for multi-class classification tasks."
       },
       SIGMOID: {
         label: "Sigmoid",
         objectName: "nn.Sigmoid",
         parameters: [],
+        description: "The sigmoid function takes any input number and squeezes it to a range between 0 and 1, effectively converting it into a probability-like value, often used for binary classification tasks and as an activation function in neural networks."
       },
       LOGSOFTMAX: {
         label: "LogSoftmax",
@@ -122,6 +134,7 @@ export const STEP_SETTINGS = {
             type: "number",
           },
         ],
+        description: "The logsoftmax function converts a set of numbers into a probability distribution using the softmax function, and then applies a logarithm to the resulting probabilities. It is commonly used for multi-class classification tasks as an activation function and to calculate the logarithmic loss during neural network training."
       }
     },
   },


### PR DESCRIPTION
Implemented an info icon feature in the Layers Inventory to enhance user experience and accessibility.

# Add Info Icon Feature to Layers Inventory

**What user problem are we solving?**
The lack of information and understanding of the various terms in the Layers Inventory poses a challenge for users without deep learning expertise. This pull request aims to address this problem by implementing an info icon feature and providing simplified descriptions for each term, enabling users to gain a high-level understanding of the functionality of each function or layer.


**What solution does this PR provide?**

This pull request introduces an info icon next to each term in the Layers Inventory. When users hover over the info icon, a popover appears, displaying a simplified description of the corresponding term. This solution empowers users without deep learning expertise to comprehend the purpose and function of each term, thereby enhancing their overall experience and accessibility within the application.


**Testing Methodology**
How did you test your changes and verify that existing 
functionality is not broken

Verified that the popovers correctly display the corresponding simplified descriptions for each term by testing on localhost

**Any other considerations**

N/A