### PR TITLE
Adding Loading Screen to User Sign-In

### DIFF
--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -28,8 +28,43 @@ import Link from "next/link";
 import Footer from "@/common/components/Footer";
 import { SerializedError } from "@reduxjs/toolkit";
 import { useRouter } from "next/router";
+import CircularProgress from "@mui/material/CircularProgress";
+
+const LoadingOverlay = () => {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        zIndex: 9999,
+        color: "#fff",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <CircularProgress color="primary" size={80} />
+        <p style={{ marginTop: 10, fontSize: 16 }}>
+          Loading... Please wait a moment
+        </p>
+      </div>
+    </div>
+  );
+};
 
 const Login = () => {
+  const [isLoading, setIsLoading] = useState(false);
   const [isRegistering, setIsRegistering] = useState(false);
   const [fullName, setFullName] = useState<string>("");
   const [email, setEmail] = useState<string>("");
@@ -65,6 +100,7 @@ const Login = () => {
             position: "relative",
           }}
           onClick={async () => {
+            setIsLoading(true);
             try {
               await dispatch(signInViaGoogleRedirect()).unwrap();
             } catch (e) {
@@ -72,6 +108,7 @@ const Login = () => {
                 position: toast.POSITION.TOP_CENTER,
               });
             }
+            setIsLoading(false);
           }}
         >
           <Image
@@ -85,6 +122,7 @@ const Login = () => {
           className="login-button github"
           style={{ position: "relative" }}
           onClick={async () => {
+            setIsLoading(true);
             try {
               await dispatch(signInViaGithubRedirect()).unwrap();
             } catch (e) {
@@ -92,6 +130,7 @@ const Login = () => {
                 position: toast.POSITION.TOP_CENTER,
               });
             }
+            setIsLoading(false);
           }}
         >
           <Image
@@ -157,6 +196,7 @@ const Login = () => {
           className="mb-2"
           onClick={async () => {
             if (isRegistering) {
+              setIsLoading(true);
               try {
                 await dispatch(
                   registerViaEmailAndPassword({
@@ -174,7 +214,9 @@ const Login = () => {
                   position: toast.POSITION.TOP_CENTER,
                 });
               }
+              setIsLoading(false);
             } else {
+              setIsLoading(true);
               try {
                 await dispatch(
                   signInViaEmailAndPassword({ email, password })
@@ -184,6 +226,7 @@ const Login = () => {
                   position: toast.POSITION.TOP_CENTER,
                 });
               }
+              setIsLoading(false);
             }
           }}
         >
@@ -199,9 +242,19 @@ const Login = () => {
       </div>
     </>
   );
+  if (isLoading) {
+    return (
+      <>
+        <NavbarMain />
+        <LoadingOverlay /> {/* Display the loading overlay */}
+      </>
+    );
+  }
+
   if (user !== undefined) {
     return <></>;
   }
+
   return (
     <>
       <NavbarMain />


### PR DESCRIPTION
# Adding Loading Screen to User Sign-In

What user problem are we solving?
Currently, when the user signs in, there is no visual indication that the authentication process is ongoing, leading to confusion and uncertainty for the users. This Pull Request aims to address this issue by overlaying a loading screen over the login page while the user is signing in or in the "pending" state. This loading screen will provide feedback to the users, assuring them that the sign-in process is underway.

What solution does this PR provide?
This PR introduces a loading screen that appears when the user clicks the sign-in button. The loading screen will be displayed until the authentication process is complete or until the user's state is no longer in the "pending" state. The loading screen will be a semi-transparent overlay over the entire login page, with a centered loading spinner.


Testing Methodology:

Tested on localhost


Any other considerations
As mentioned earlier, while this PR introduces the loading screen for the login page, there might be a momentary blank page issue when the user is redirected to the dashboard page after authentication. This behavior will be addressed in subsequent PRs by implementing skeleton loading for login-protected pages to provide a better user experience, as @dwu359 mentioned in the corresponding linked issue.

In summary, this PR lays the groundwork for the loading screen on the login page during the authentication process. The minor issue with the blank page during redirection will be tackled in future commits.