### PR TITLE
Integration with S3 for Reading and Uploading CSV Files

### DIFF
--- a/.github/workflows/python-package-poetry.yml
+++ b/.github/workflows/python-package-poetry.yml
@@ -36,6 +36,16 @@ jobs:
           installer-parallel: true
 
       #----------------------------------------------
+      # Configure AWS credentials from GitHub secrets
+      #----------------------------------------------
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------
       - name: Load cached venv

--- a/.github/workflows/python-package-poetry.yml
+++ b/.github/workflows/python-package-poetry.yml
@@ -34,17 +34,6 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-
-      #----------------------------------------------
-      # Configure AWS credentials from GitHub secrets
-      #----------------------------------------------
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------
@@ -62,9 +51,13 @@ jobs:
         run: cd backend && poetry install --no-interaction --no-root
 
       #----------------------------------------------
-      #              run test suite
+      #              run test suite with moto
       #----------------------------------------------
-      - name: Run tests
+      - name: Run tests with moto
         run: |
           source backend/.venv/bin/activate
+          moto_server s3 -p 5000 &  # Start moto S3 server in the background
+          export AWS_ACCESS_KEY_ID=testing
+          export AWS_SECRET_ACCESS_KEY=testing
+          export AWS_DEFAULT_REGION=us-west-2
           cd backend && pytest tests

--- a/.github/workflows/python-package-poetry.yml
+++ b/.github/workflows/python-package-poetry.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: us-west-2
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/backend/common/dataset.py
+++ b/backend/common/dataset.py
@@ -17,13 +17,13 @@ from io import StringIO
 from common.constants import *
 import requests
 from io import BytesIO
+from aws_helpers.s3_utils.s3_client import write_to_bucket
 
 FILE_UPLOAD_BUCKET_NAME = "dlp-upload-bucket"
 
-
 def read_dataset(url):
     """
-    Given a url to a CSV dataset, read it and build temporary csv file
+    Given a url to a CSV dataset, read it and build a temporary csv file
 
     Args:
         url (str): URL to dataset
@@ -39,17 +39,13 @@ def read_dataset(url):
         csv_data_bytes = csv_data.getvalue().encode("utf-8")
 
         # Upload the temporary CSV file to the file upload S3 bucket
-        s3 = boto3.client("s3")
-        s3.upload_fileobj(
-            BytesIO(csv_data_bytes), FILE_UPLOAD_BUCKET_NAME, csv_file_name
-        )
+        write_to_bucket(BytesIO(csv_data_bytes), FILE_UPLOAD_BUCKET_NAME, csv_file_name)
 
     except Exception as e:
         traceback.print_exc()
         raise Exception(
             "Reading Dataset from URL and uploading to S3 failed. Please check the validity of the URL."
         )
-
 
 def read_local_csv_file(file_path):
     """

--- a/backend/common/dataset.py
+++ b/backend/common/dataset.py
@@ -20,6 +20,7 @@ from io import BytesIO
 
 FILE_UPLOAD_BUCKET_NAME = "dlp-upload-bucket"
 
+
 def read_dataset(url):
     """
     Given a url to a CSV dataset, read it and build temporary csv file
@@ -30,7 +31,7 @@ def read_dataset(url):
     try:
         r = requests.get(url).text
         csv_data = StringIO(r)
-        
+
         # Define the name of the temporary CSV file
         csv_file_name = "data.csv"
 
@@ -38,15 +39,17 @@ def read_dataset(url):
         csv_data_bytes = csv_data.getvalue().encode("utf-8")
 
         # Upload the temporary CSV file to the file upload S3 bucket
-        s3 = boto3.client('s3')
-        s3.upload_fileobj(BytesIO(csv_data_bytes), FILE_UPLOAD_BUCKET_NAME, csv_file_name)
-
+        s3 = boto3.client("s3")
+        s3.upload_fileobj(
+            BytesIO(csv_data_bytes), FILE_UPLOAD_BUCKET_NAME, csv_file_name
+        )
 
     except Exception as e:
         traceback.print_exc()
         raise Exception(
             "Reading Dataset from URL and uploading to S3 failed. Please check the validity of the URL."
         )
+
 
 def read_local_csv_file(file_path):
     """

--- a/backend/common/dataset.py
+++ b/backend/common/dataset.py
@@ -36,20 +36,22 @@ def read_dataset(url):
         # Define the name of the temporary CSV file
         csv_file_name = "data.csv"
 
-        # Encode the StringIO object as bytes before uploading to S3
-        csv_data_bytes = csv_data.getvalue().encode("utf-8")
+        # Write the StringIO data to a local temporary file
+        with open(csv_file_name, mode="w", encoding="utf-8") as f:
+            f.write(csv_data.getvalue())
 
         # Upload the temporary CSV file to the file upload S3 bucket
-        write_to_bucket(BytesIO(csv_data_bytes), FILE_UPLOAD_BUCKET_NAME, csv_file_name)
+        write_to_bucket(csv_file_name, FILE_UPLOAD_BUCKET_NAME, csv_file_name)
 
         # Remove the local temporary CSV file after uploading
         os.remove(csv_file_name)
-        
+
     except Exception as e:
         traceback.print_exc()
         raise Exception(
             "Reading Dataset from URL and uploading to S3 failed. Please check the validity of the URL."
         )
+
 
 
 def read_local_csv_file(file_path):

--- a/backend/common/dataset.py
+++ b/backend/common/dataset.py
@@ -21,6 +21,7 @@ from aws_helpers.s3_utils.s3_client import write_to_bucket
 
 FILE_UPLOAD_BUCKET_NAME = "dlp-upload-bucket"
 
+
 def read_dataset(url):
     """
     Given a url to a CSV dataset, read it and build a temporary csv file
@@ -46,6 +47,7 @@ def read_dataset(url):
         raise Exception(
             "Reading Dataset from URL and uploading to S3 failed. Please check the validity of the URL."
         )
+
 
 def read_local_csv_file(file_path):
     """

--- a/backend/common/dataset.py
+++ b/backend/common/dataset.py
@@ -53,7 +53,6 @@ def read_dataset(url):
         )
 
 
-
 def read_local_csv_file(file_path):
     """
     Given a local file path or the "uploaded CSV file", read it in pandas dataframe

--- a/backend/common/dataset.py
+++ b/backend/common/dataset.py
@@ -41,6 +41,9 @@ def read_dataset(url):
         # Upload the temporary CSV file to the file upload S3 bucket
         write_to_bucket(BytesIO(csv_data_bytes), FILE_UPLOAD_BUCKET_NAME, csv_file_name)
 
+        # Remove the local temporary CSV file after uploading
+        os.remove(csv_file_name)
+        
     except Exception as e:
         traceback.print_exc()
         raise Exception(

--- a/backend/common/dataset.py
+++ b/backend/common/dataset.py
@@ -44,7 +44,7 @@ def read_dataset(url):
 
         # Remove the local temporary CSV file after uploading
         os.remove(csv_file_name)
-        
+
     except Exception as e:
         traceback.print_exc()
         raise Exception(

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2581,13 +2581,13 @@ files = [
 
 [[package]]
 name = "moto"
-version = "4.1.13"
+version = "4.1.14"
 description = ""
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "moto-4.1.13-py2.py3-none-any.whl", hash = "sha256:9650d05d89b6f97043695548fbc0d8fb293f4177daaebbcee00bb0d171367f1a"},
-    {file = "moto-4.1.13.tar.gz", hash = "sha256:dd3e2ad920ab8b058c4f62fa7c195b788bd1f018cc701a1868ff5d5c4de6ed47"},
+    {file = "moto-4.1.14-py2.py3-none-any.whl", hash = "sha256:7d3bd748a34641715ba469c761f72fb8ec18f349987c98f5a0f9be85a07a9911"},
+    {file = "moto-4.1.14.tar.gz", hash = "sha256:545afeb4df94dfa730e2d7e87366dc26b4a33c2891f462cbb049f040c80ed1ec"},
 ]
 
 [package.dependencies]
@@ -2602,17 +2602,17 @@ werkzeug = ">=0.5,<2.2.0 || >2.2.0,<2.2.1 || >2.2.1"
 xmltodict = "*"
 
 [package.extras]
-all = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.3)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+all = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.6)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
 apigateway = ["PyYAML (>=5.1)", "ecdsa (!=0.15)", "openapi-spec-validator (>=0.2.8)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
 apigatewayv2 = ["PyYAML (>=5.1)"]
 appsync = ["graphql-core"]
 awslambda = ["docker (>=3.0.0)"]
 batch = ["docker (>=3.0.0)"]
-cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.3)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.6)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
 cognitoidp = ["ecdsa (!=0.15)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
 ds = ["sshpubkeys (>=3.1.0)"]
-dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.3.3)"]
-dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.3.3)"]
+dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.3.6)"]
+dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.3.6)"]
 ebs = ["sshpubkeys (>=3.1.0)"]
 ec2 = ["sshpubkeys (>=3.1.0)"]
 efs = ["sshpubkeys (>=3.1.0)"]
@@ -2620,8 +2620,9 @@ eks = ["sshpubkeys (>=3.1.0)"]
 glue = ["pyparsing (>=3.0.7)"]
 iotdata = ["jsondiff (>=1.1.2)"]
 route53resolver = ["sshpubkeys (>=3.1.0)"]
-s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.3.3)"]
-server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.3)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.3.6)"]
+s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.3.6)"]
+server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.2.8)", "py-partiql-parser (==0.3.6)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
 ssm = ["PyYAML (>=5.1)"]
 xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
@@ -5570,4 +5571,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <3.10"
-content-hash = "4adb239b0220e88677f453c31b7aaf2edb92bcdc651f3b7c0da94824d6f630f4"
+content-hash = "d3e3e6def554642896b5747057e5ab5553252553ff4b15685ae46c5dd2eaa957"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -42,6 +42,7 @@ pytest = "^7.4.0"
 flake8 = "^6.0.0"
 jupyter = "^1.0.0"
 black = "^23.7.0"
+moto = "^4.1.14"
 
 [build-system]
 requires = ["poetry-core"]

--- a/backend/tests/test_data_processing.py
+++ b/backend/tests/test_data_processing.py
@@ -9,14 +9,19 @@ from common.dataset import read_dataset
 
 # Define the S3 bucket name
 S3_BUCKET_NAME = "dlp-upload-bucket"
-S3_REGION = "us-west-2" 
+S3_REGION = "us-west-2"
+
 
 @pytest.fixture
 def s3_client():
     with mock_s3():
         s3 = boto3.client("s3", region_name=S3_REGION)
-        s3.create_bucket(Bucket=S3_BUCKET_NAME, CreateBucketConfiguration={"LocationConstraint": S3_REGION})
+        s3.create_bucket(
+            Bucket=S3_BUCKET_NAME,
+            CreateBucketConfiguration={"LocationConstraint": S3_REGION},
+        )
         yield s3
+
 
 @pytest.mark.parametrize(
     "url,path_to_file",
@@ -48,6 +53,7 @@ def test_dataset_url_reading(url, path_to_file, s3_client):
 
     except Exception as e:
         pytest.fail(str(e))
+
 
 @pytest.mark.parametrize(
     "url,path_to_file",

--- a/backend/tests/test_data_processing.py
+++ b/backend/tests/test_data_processing.py
@@ -9,6 +9,7 @@ from common.dataset import read_dataset
 
 # Define the S3 bucket name
 S3_BUCKET_NAME = "dlp-upload-bucket"
+S3_REGION = "us-west-2"
 
 @pytest.mark.parametrize(
     "url,path_to_file",
@@ -27,7 +28,7 @@ S3_BUCKET_NAME = "dlp-upload-bucket"
 def test_dataset_url_reading(url, path_to_file):
     try:
         # Create the S3 bucket before running the test
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", region_name=S3_REGION)
         s3.create_bucket(Bucket=S3_BUCKET_NAME)
 
         # Call read_dataset, which should upload the CSV to the mock S3 bucket

--- a/backend/tests/test_data_processing.py
+++ b/backend/tests/test_data_processing.py
@@ -11,6 +11,7 @@ from common.dataset import read_dataset
 # Define the S3 bucket name
 S3_BUCKET_NAME = "dlp-upload-bucket"
 
+
 @pytest.mark.parametrize(
     "url,path_to_file",
     [
@@ -29,13 +30,13 @@ def test_dataset_url_reading(url, path_to_file):
         read_dataset(url)
 
         # Upload the test data to the S3 bucket before running the test
-        with open(path_to_file, 'rb') as f:
-            s3 = boto3.client('s3')
+        with open(path_to_file, "rb") as f:
+            s3 = boto3.client("s3")
             s3.put_object(Bucket=S3_BUCKET_NAME, Key="data.csv", Body=f)
 
         # Download the CSV data from S3
         s3_response = s3.get_object(Bucket=S3_BUCKET_NAME, Key="data.csv")
-        s3_data = s3_response['Body'].read().decode("utf8")
+        s3_data = s3_response["Body"].read().decode("utf8")
 
         with open(path_to_file) as f:
             expected_data = f.read()

--- a/backend/tests/test_data_processing.py
+++ b/backend/tests/test_data_processing.py
@@ -10,6 +10,7 @@ from common.dataset import read_dataset
 # Define the S3 bucket name
 S3_BUCKET_NAME = "dlp-upload-bucket"
 
+
 @pytest.mark.parametrize(
     "url,path_to_file",
     [
@@ -45,6 +46,7 @@ def test_dataset_url_reading(url, path_to_file):
 
     except Exception as e:
         pytest.fail(str(e))
+
 
 @pytest.mark.parametrize(
     "url,path_to_file",

--- a/backend/tests/test_data_processing.py
+++ b/backend/tests/test_data_processing.py
@@ -9,8 +9,14 @@ from common.dataset import read_dataset
 
 # Define the S3 bucket name
 S3_BUCKET_NAME = "dlp-upload-bucket"
-S3_REGION = "us-west-2"
+S3_REGION = "us-west-2" 
 
+@pytest.fixture
+def s3_client():
+    with mock_s3():
+        s3 = boto3.client("s3", region_name=S3_REGION)
+        s3.create_bucket(Bucket=S3_BUCKET_NAME, CreateBucketConfiguration={"LocationConstraint": S3_REGION})
+        yield s3
 
 @pytest.mark.parametrize(
     "url,path_to_file",
@@ -25,18 +31,13 @@ S3_REGION = "us-west-2"
         ),
     ],
 )
-@mock_s3
-def test_dataset_url_reading(url, path_to_file):
+def test_dataset_url_reading(url, path_to_file, s3_client):
     try:
-        # Create the S3 bucket before running the test
-        s3 = boto3.client("s3", region_name=S3_REGION)
-        s3.create_bucket(Bucket=S3_BUCKET_NAME)
-
         # Call read_dataset, which should upload the CSV to the mock S3 bucket
         read_dataset(url)
 
         # Download the CSV data from the mock S3 bucket
-        s3_response = s3.get_object(Bucket=S3_BUCKET_NAME, Key="data.csv")
+        s3_response = s3_client.get_object(Bucket=S3_BUCKET_NAME, Key="data.csv")
         s3_data = s3_response["Body"].read().decode("utf-8")
 
         with open(path_to_file) as f:
@@ -48,7 +49,6 @@ def test_dataset_url_reading(url, path_to_file):
     except Exception as e:
         pytest.fail(str(e))
 
-
 @pytest.mark.parametrize(
     "url,path_to_file",
     [
@@ -56,7 +56,6 @@ def test_dataset_url_reading(url, path_to_file):
         ("csv.com/cars.csv", "./tests/expected/cars.csv"),
     ],
 )
-@mock_s3
-def test_dataset_invalid_url(url, path_to_file):
+def test_dataset_invalid_url(url, path_to_file, s3_client):
     with pytest.raises(Exception):
         read_dataset(url)

--- a/backend/tests/test_data_processing.py
+++ b/backend/tests/test_data_processing.py
@@ -1,16 +1,14 @@
-# Import necessary libraries
-from urllib.error import URLError
 import pytest
 import csv
 import boto3
 from botocore.exceptions import ClientError
 from io import StringIO
+from moto import mock_s3
 from common.constants import *
 from common.dataset import read_dataset
 
 # Define the S3 bucket name
 S3_BUCKET_NAME = "dlp-upload-bucket"
-
 
 @pytest.mark.parametrize(
     "url,path_to_file",
@@ -25,28 +23,28 @@ S3_BUCKET_NAME = "dlp-upload-bucket"
         ),
     ],
 )
+@mock_s3
 def test_dataset_url_reading(url, path_to_file):
     try:
+        # Create the S3 bucket before running the test
+        s3 = boto3.client("s3")
+        s3.create_bucket(Bucket=S3_BUCKET_NAME)
+
+        # Call read_dataset, which should upload the CSV to the mock S3 bucket
         read_dataset(url)
 
-        # Upload the test data to the S3 bucket before running the test
-        with open(path_to_file, "rb") as f:
-            s3 = boto3.client("s3")
-            s3.put_object(Bucket=S3_BUCKET_NAME, Key="data.csv", Body=f)
-
-        # Download the CSV data from S3
+        # Download the CSV data from the mock S3 bucket
         s3_response = s3.get_object(Bucket=S3_BUCKET_NAME, Key="data.csv")
-        s3_data = s3_response["Body"].read().decode("utf8")
+        s3_data = s3_response["Body"].read().decode("utf-8")
 
         with open(path_to_file) as f:
             expected_data = f.read()
 
-        # Compare the content of the CSV file uploaded to S3 with the expected CSV file
+        # Compare the content of the CSV file uploaded to the mock S3 bucket with the expected CSV file
         assert s3_data == expected_data
 
     except Exception as e:
         pytest.fail(str(e))
-
 
 @pytest.mark.parametrize(
     "url,path_to_file",
@@ -55,6 +53,7 @@ def test_dataset_url_reading(url, path_to_file):
         ("csv.com/cars.csv", "./tests/expected/cars.csv"),
     ],
 )
+@mock_s3
 def test_dataset_invalid_url(url, path_to_file):
     with pytest.raises(Exception):
         read_dataset(url)


### PR DESCRIPTION
# read_dataset(url) Integration with S3 for Reading and Uploading CSV Files

**What user problem are we solving?**
Currently, the read_dataset(url) function in ai_drive.py reads a CSV file from a given URL and stores it locally as data.csv. However, as the team is shifting towards using S3 for storing user-uploaded data files, we need to modify this function to integrate with S3 for uploading the CSV files directly to S3 instead of saving them locally.

**What solution does this PR provide?**
This PR refactors the read_dataset(url) function in ai_drive.py to handle CSV files as follows:

- Parses the CSV file name from the URL itself or uses a generic name provided by the user.
- Reads the CSV contents and builds a temporary file in memory (not stored locally).
- Uploads the temporary CSV file to an S3 bucket.

The refactored function will now interact with S3 for file storage, which aligns with the team's new approach to data handling.


**Testing Methodology**
I tested the changes in the test_dataset_url_reading function within test_data_processing.py to ensure that the integration with S3 for reading and uploading CSV files worked as expected. The tests included the following:

Tested with jobs.csv URL: Executed the test_dataset_url_reading function with a URL pointing to the jobs.csv dataset. The test confirmed that the function could read the CSV contents from the URL, build a temporary file in memory, and successfully upload it to the designated S3 bucket.

Tested with cars.csv URL: Similarly, I tested the function with a URL pointing to the cars.csv dataset. The test validated that the CSV file was read, processed, and uploaded to S3 without any issues.

Both tests passed, demonstrating that the modifications to the read_dataset(url) function and its integration with S3 were successful and did not break existing functionality.

**Any other considerations**

N/A