### PR TITLE
Speed up react build checks

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,12 +21,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/cache@v3
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: "yarn"
-      - run: yarn install
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.cache-yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
         working-directory: ./frontend
       - run: yarn lint
         working-directory: ./frontend


### PR DESCRIPTION
# Speed up react build checks

**What user problem are we solving?**

When minor changes are made to frontend directory, yarn install is run resulting in rather slow build times.

**What solution does this PR provide?**

This solution takes advantage of actions/cache@v3 and caches node_modules to prevent redundant yarn installations.

**Testing Methodology**
How did you test your changes and verify that existing 
functionality is not broken

I ran the workflow through GitHub Actions and noticed it went from over 1 minute build times to around 30 seconds. Solid improvement!

**Any other considerations**
Since we're caching the node_modules directory itself, we must be mindful when changing node versions. However, since we assert the node version in the workflow itself, this shouldn't be an issue.