### PR TITLE
Fix auth

### DIFF
--- a/.github/Architecture.md
+++ b/.github/Architecture.md
@@ -6,42 +6,42 @@
 📦 backend
 |  |- 📂 aws_helpers:
 |  |  |- 📂 dynamo_db_utils:
-|  |  |  |- 📜 userprogress_db.py
 |  |  |  |- 📜 DynamoUnitTests.md
 |  |  |  |- 📜 dynamo_db_utils.py
-|  |  |  |- 📜 constants.py : list of helpful constants
 |  |  |  |- 📜 trainspace_db.py
+|  |  |  |- 📜 constants.py : list of helpful constants
+|  |  |  |- 📜 userprogress_db.py
 |  |  |- 📜 __init__.py
-|  |- 📂 dl:
-|  |  |- 📜 dl_eval.py : Evaluation functions for deep learning models in Pytorch (eg: accuracy, loss, etc)
-|  |  |- 📜 dl_model_parser.py : parse the user specified pytorch model
-|  |  |- 📜 dl_trainer.py : train a deep learning model on the dataset
-|  |  |- 📜 detection.py
-|  |  |- 📜 dl_model.py : torch model based on user specifications from drag and drop
-|  |  |- 📜 __init__.py
-|  |- 📂 common:
-|  |  |- 📜 dataset.py : read in the dataset through URL or file upload
-|  |  |- 📜 default_datasets.py : store logic to load in default datasets from scikit-learn
-|  |  |- 📜 preprocessing.py
-|  |  |- 📜 kernel.py
-|  |  |- 📜 loss_functions.py : loss function enum
-|  |  |- 📜 email_notifier.py : Endpoint to send email notification of training results via API Gateway + AWS SES
-|  |  |- 📜 constants.py : list of helpful constants
-|  |  |- 📜 utils.py : utility functions that could be helpful
-|  |  |- 📜 optimizer.py : what optimizer to use (ie: SGD or Adam for now)
-|  |  |- 📜 __init__.py
-|  |  |- 📜 ai_drive.py
 |  |- 📂 ml:
-|  |  |- 📜 ml_model_parser.py
 |  |  |- 📜 ml_trainer.py : train a classical machine learning learning model on the dataset
 |  |  |- 📜 __init__.py
-|  |- 📜 pyproject.toml
-|  |- 📜 epoch_times.csv
-|  |- 📜 data.csv : data csv file for use in the playground
-|  |- 📜 poetry.lock
-|  |- 📜 middleware.py
+|  |  |- 📜 ml_model_parser.py
+|  |- 📂 dl:
+|  |  |- 📜 __init__.py
+|  |  |- 📜 dl_trainer.py : train a deep learning model on the dataset
+|  |  |- 📜 dl_model.py : torch model based on user specifications from drag and drop
+|  |  |- 📜 dl_model_parser.py : parse the user specified pytorch model
+|  |  |- 📜 detection.py
+|  |  |- 📜 dl_eval.py : Evaluation functions for deep learning models in Pytorch (eg: accuracy, loss, etc)
+|  |- 📂 common:
+|  |  |- 📜 default_datasets.py : store logic to load in default datasets from scikit-learn
+|  |  |- 📜 __init__.py
+|  |  |- 📜 preprocessing.py
+|  |  |- 📜 dataset.py : read in the dataset through URL or file upload
+|  |  |- 📜 constants.py : list of helpful constants
+|  |  |- 📜 optimizer.py : what optimizer to use (ie: SGD or Adam for now)
+|  |  |- 📜 ai_drive.py
+|  |  |- 📜 email_notifier.py : Endpoint to send email notification of training results via API Gateway + AWS SES
+|  |  |- 📜 loss_functions.py : loss function enum
+|  |  |- 📜 kernel.py
+|  |  |- 📜 utils.py : utility functions that could be helpful
 |  |- 📜 __init__.py
+|  |- 📜 middleware.py
+|  |- 📜 poetry.lock
+|  |- 📜 epoch_times.csv
 |  |- 📜 app.py : run the backend (entrypoint script)
+|  |- 📜 data.csv : data csv file for use in the playground
+|  |- 📜 pyproject.toml
 ```
 
 ## Frontend Architecture
@@ -49,112 +49,112 @@
 ```
 📦 frontend
 |  |- 📂 src:
-|  |  |- 📂 pages:
-|  |  |  |- 📂 train:
-|  |  |  |  |- 📜 index.tsx
-|  |  |  |  |- 📜 [train_space_id].tsx
-|  |  |  |- 📜 LearnContent.tsx
-|  |  |  |- 📜 feedback.tsx
-|  |  |  |- 📜 _document.tsx
-|  |  |  |- 📜 learn.tsx
-|  |  |  |- 📜 login.tsx
-|  |  |  |- 📜 about.tsx
-|  |  |  |- 📜 _app.tsx
-|  |  |  |- 📜 settings.tsx
-|  |  |  |- 📜 forgot.tsx
-|  |  |  |- 📜 wiki.tsx
-|  |  |  |- 📜 dashboard.tsx
 |  |  |- 📂 backend_outputs:
-|  |  |  |- 📜 model.pkl
 |  |  |  |- 📜 model.pt : Last model.pt output
 |  |  |  |- 📜 my_deep_learning_model.onnx : Last ONNX file output
+|  |  |  |- 📜 model.pkl
+|  |  |- 📂 pages:
+|  |  |  |- 📂 train:
+|  |  |  |  |- 📜 [train_space_id].tsx
+|  |  |  |  |- 📜 index.tsx
+|  |  |  |- 📜 feedback.tsx
+|  |  |  |- 📜 settings.tsx
+|  |  |  |- 📜 _app.tsx
+|  |  |  |- 📜 learn.tsx
+|  |  |  |- 📜 login.tsx
+|  |  |  |- 📜 wiki.tsx
+|  |  |  |- 📜 _document.tsx
+|  |  |  |- 📜 about.tsx
+|  |  |  |- 📜 forgot.tsx
+|  |  |  |- 📜 dashboard.tsx
+|  |  |  |- 📜 LearnContent.tsx
 |  |  |- 📂 features:
-|  |  |  |- 📂 Feedback:
-|  |  |  |  |- 📂 redux:
-|  |  |  |  |  |- 📜 feedbackApi.ts
-|  |  |  |- 📂 Dashboard:
-|  |  |  |  |- 📂 components:
-|  |  |  |  |  |- 📜 TrainDataGrid.tsx
-|  |  |  |  |  |- 📜 TrainBarChart.tsx
-|  |  |  |  |  |- 📜 TrainDoughnutChart.tsx
-|  |  |  |  |- 📂 redux:
-|  |  |  |  |  |- 📜 dashboardApi.ts
-|  |  |  |- 📂 LearnMod:
-|  |  |  |  |- 📜 ImageComponent.tsx
-|  |  |  |  |- 📜 ModulesSideBar.tsx
-|  |  |  |  |- 📜 ClassCard.tsx
-|  |  |  |  |- 📜 LearningModulesContent.tsx
-|  |  |  |  |- 📜 MCQuestion.tsx
-|  |  |  |  |- 📜 FRQuestion.tsx
-|  |  |  |  |- 📜 Exercise.tsx
-|  |  |  |- 📂 OpenAi:
-|  |  |  |  |- 📜 openAiUtils.ts
 |  |  |  |- 📂 Train:
-|  |  |  |  |- 📂 types:
-|  |  |  |  |  |- 📜 trainTypes.ts
-|  |  |  |  |- 📂 components:
-|  |  |  |  |  |- 📜 CreateTrainspace.tsx
-|  |  |  |  |  |- 📜 TrainspaceLayout.tsx
-|  |  |  |  |  |- 📜 DatasetStepLayout.tsx
+|  |  |  |  |- 📂 constants:
+|  |  |  |  |  |- 📜 trainConstants.ts
 |  |  |  |  |- 📂 features:
-|  |  |  |  |  |- 📂 Tabular:
-|  |  |  |  |  |  |- 📂 types:
-|  |  |  |  |  |  |  |- 📜 tabularTypes.ts
-|  |  |  |  |  |  |- 📂 components:
-|  |  |  |  |  |  |  |- 📜 TabularReviewStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularDatasetStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularTrainspace.tsx
-|  |  |  |  |  |  |  |- 📜 TabularParametersStep.tsx
-|  |  |  |  |  |  |- 📂 constants:
-|  |  |  |  |  |  |  |- 📜 tabularConstants.ts
-|  |  |  |  |  |  |- 📂 redux:
-|  |  |  |  |  |  |  |- 📜 tabularActions.ts
-|  |  |  |  |  |  |  |- 📜 tabularApi.ts
-|  |  |  |  |  |  |- 📜 index.ts
 |  |  |  |  |  |- 📂 Image:
-|  |  |  |  |  |  |- 📂 types:
-|  |  |  |  |  |  |  |- 📜 imageTypes.ts
-|  |  |  |  |  |  |- 📂 components:
-|  |  |  |  |  |  |  |- 📜 ImageTrainspace.tsx
-|  |  |  |  |  |  |  |- 📜 ImageParametersStep.tsx
-|  |  |  |  |  |  |  |- 📜 ImageDatasetStep.tsx
-|  |  |  |  |  |  |  |- 📜 ImageReviewStep.tsx
 |  |  |  |  |  |  |- 📂 constants:
 |  |  |  |  |  |  |  |- 📜 imageConstants.ts
+|  |  |  |  |  |  |- 📂 components:
+|  |  |  |  |  |  |  |- 📜 ImageTrainspace.tsx
+|  |  |  |  |  |  |  |- 📜 ImageDatasetStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageReviewStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageParametersStep.tsx
+|  |  |  |  |  |  |- 📂 types:
+|  |  |  |  |  |  |  |- 📜 imageTypes.ts
 |  |  |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |  |  |- 📜 imageActions.ts
 |  |  |  |  |  |  |  |- 📜 imageApi.ts
 |  |  |  |  |  |  |- 📜 index.ts
-|  |  |  |  |- 📂 constants:
-|  |  |  |  |  |- 📜 trainConstants.ts
+|  |  |  |  |  |- 📂 Tabular:
+|  |  |  |  |  |  |- 📂 constants:
+|  |  |  |  |  |  |  |- 📜 tabularConstants.ts
+|  |  |  |  |  |  |- 📂 components:
+|  |  |  |  |  |  |  |- 📜 TabularParametersStep.tsx
+|  |  |  |  |  |  |  |- 📜 TabularDatasetStep.tsx
+|  |  |  |  |  |  |  |- 📜 TabularTrainspace.tsx
+|  |  |  |  |  |  |  |- 📜 TabularReviewStep.tsx
+|  |  |  |  |  |  |- 📂 types:
+|  |  |  |  |  |  |  |- 📜 tabularTypes.ts
+|  |  |  |  |  |  |- 📂 redux:
+|  |  |  |  |  |  |  |- 📜 tabularActions.ts
+|  |  |  |  |  |  |  |- 📜 tabularApi.ts
+|  |  |  |  |  |  |- 📜 index.ts
+|  |  |  |  |- 📂 components:
+|  |  |  |  |  |- 📜 CreateTrainspace.tsx
+|  |  |  |  |  |- 📜 DatasetStepLayout.tsx
+|  |  |  |  |  |- 📜 TrainspaceLayout.tsx
+|  |  |  |  |- 📂 types:
+|  |  |  |  |  |- 📜 trainTypes.ts
 |  |  |  |  |- 📂 redux:
-|  |  |  |  |  |- 📜 trainspaceSlice.ts
 |  |  |  |  |  |- 📜 trainspaceApi.ts
+|  |  |  |  |  |- 📜 trainspaceSlice.ts
+|  |  |  |- 📂 Dashboard:
+|  |  |  |  |- 📂 components:
+|  |  |  |  |  |- 📜 TrainDoughnutChart.tsx
+|  |  |  |  |  |- 📜 TrainBarChart.tsx
+|  |  |  |  |  |- 📜 TrainDataGrid.tsx
+|  |  |  |  |- 📂 redux:
+|  |  |  |  |  |- 📜 dashboardApi.ts
+|  |  |  |- 📂 LearnMod:
+|  |  |  |  |- 📜 LearningModulesContent.tsx
+|  |  |  |  |- 📜 Exercise.tsx
+|  |  |  |  |- 📜 ImageComponent.tsx
+|  |  |  |  |- 📜 ModulesSideBar.tsx
+|  |  |  |  |- 📜 MCQuestion.tsx
+|  |  |  |  |- 📜 FRQuestion.tsx
+|  |  |  |  |- 📜 ClassCard.tsx
+|  |  |  |- 📂 Feedback:
+|  |  |  |  |- 📂 redux:
+|  |  |  |  |  |- 📜 feedbackApi.ts
+|  |  |  |- 📂 OpenAi:
+|  |  |  |  |- 📜 openAiUtils.ts
 |  |  |- 📂 common:
-|  |  |  |- 📂 components:
-|  |  |  |  |- 📜 EmailInput.tsx
-|  |  |  |  |- 📜 ClientOnlyPortal.tsx
-|  |  |  |  |- 📜 Footer.tsx
-|  |  |  |  |- 📜 Spacer.tsx
-|  |  |  |  |- 📜 TitleText.tsx
-|  |  |  |  |- 📜 NavBarMain.tsx
-|  |  |  |- 📂 utils:
-|  |  |  |  |- 📜 dateFormat.ts
-|  |  |  |  |- 📜 firebase.ts
-|  |  |  |  |- 📜 dndHelpers.ts
-|  |  |  |- 📂 redux:
-|  |  |  |  |- 📜 userLogin.ts
-|  |  |  |  |- 📜 train.ts
-|  |  |  |  |- 📜 backendApi.ts
-|  |  |  |  |- 📜 store.ts
-|  |  |  |  |- 📜 hooks.ts
 |  |  |  |- 📂 styles:
 |  |  |  |  |- 📜 globals.css
 |  |  |  |  |- 📜 Home.module.css
-|  |  |- 📜 GlobalStyle.ts
-|  |  |- 📜 next-env.d.ts
+|  |  |  |- 📂 components:
+|  |  |  |  |- 📜 ClientOnlyPortal.tsx
+|  |  |  |  |- 📜 EmailInput.tsx
+|  |  |  |  |- 📜 TitleText.tsx
+|  |  |  |  |- 📜 NavBarMain.tsx
+|  |  |  |  |- 📜 Footer.tsx
+|  |  |  |  |- 📜 Spacer.tsx
+|  |  |  |- 📂 utils:
+|  |  |  |  |- 📜 firebase.ts
+|  |  |  |  |- 📜 dateFormat.ts
+|  |  |  |  |- 📜 dndHelpers.ts
+|  |  |  |- 📂 redux:
+|  |  |  |  |- 📜 backendApi.ts
+|  |  |  |  |- 📜 userLogin.ts
+|  |  |  |  |- 📜 hooks.ts
+|  |  |  |  |- 📜 store.ts
+|  |  |  |  |- 📜 train.ts
 |  |  |- 📜 iris.csv : Sample CSV data
+|  |  |- 📜 next-env.d.ts
 |  |  |- 📜 constants.ts
+|  |  |- 📜 GlobalStyle.ts
 |  |- 📂 layer_docs:
 |  |  |- 📜 Linear.md : Doc for Linear layer
 |  |  |- 📜 Softmax.md : Doc for Softmax layer
@@ -162,61 +162,61 @@
 |  |  |- 📜 ReLU.md : Doc for ReLU later
 |  |- 📂 public:
 |  |  |- 📂 images:
-|  |  |  |- 📂 wiki_images:
-|  |  |  |  |- 📜 tanh_plot.png
-|  |  |  |  |- 📜 sigmoid_equation.png
-|  |  |  |  |- 📜 avgpool_maxpool.gif
-|  |  |  |  |- 📜 maxpool2d.gif
-|  |  |  |  |- 📜 batchnorm_diagram.png
-|  |  |  |  |- 📜 conv2d2.gif
-|  |  |  |  |- 📜 conv2d.gif
-|  |  |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
-|  |  |  |  |- 📜 dropout_diagram.png
-|  |  |  |  |- 📜 tanh_equation.png
 |  |  |  |- 📂 logos:
 |  |  |  |  |- 📂 dlp_branding:
 |  |  |  |  |  |- 📜 dlp-logo.svg : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
 |  |  |  |  |  |- 📜 dlp-logo.png : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
-|  |  |  |  |- 📜 google.png
-|  |  |  |  |- 📜 dsgt-logo-white-back.png
 |  |  |  |  |- 📜 dsgt-logo-dark.png
-|  |  |  |  |- 📜 dsgt-logo-light.png
-|  |  |  |  |- 📜 pytorch-logo.png
 |  |  |  |  |- 📜 github.png
-|  |  |  |  |- 📜 aws-logo.png
-|  |  |  |  |- 📜 python-logo.png
+|  |  |  |  |- 📜 dsgt-logo-light.png
 |  |  |  |  |- 📜 pandas-logo.png
 |  |  |  |  |- 📜 react-logo.png
+|  |  |  |  |- 📜 python-logo.png
 |  |  |  |  |- 📜 flask-logo.png
+|  |  |  |  |- 📜 pytorch-logo.png
+|  |  |  |  |- 📜 aws-logo.png
+|  |  |  |  |- 📜 google.png
+|  |  |  |  |- 📜 dsgt-logo-white-back.png
 |  |  |  |- 📂 learn_mod_images:
-|  |  |  |  |- 📜 robotImage.jpg
-|  |  |  |  |- 📜 sigmoidfunction.png
-|  |  |  |  |- 📜 lossExampleEquation.png
-|  |  |  |  |- 📜 LeakyReLUactivation.png
-|  |  |  |  |- 📜 lossExample.png
-|  |  |  |  |- 📜 neuron.png
-|  |  |  |  |- 📜 tanhactivation.png
-|  |  |  |  |- 📜 neuronWithEquation.png
 |  |  |  |  |- 📜 lossExampleTable.png
-|  |  |  |  |- 📜 ReLUactivation.png
-|  |  |  |  |- 📜 neuralnet.png
+|  |  |  |  |- 📜 tanhactivation.png
 |  |  |  |  |- 📜 sigmoidactivation.png
+|  |  |  |  |- 📜 LeakyReLUactivation.png
+|  |  |  |  |- 📜 ReLUactivation.png
+|  |  |  |  |- 📜 robotImage.jpg
+|  |  |  |  |- 📜 lossExample.png
 |  |  |  |  |- 📜 binarystepactivation.png
+|  |  |  |  |- 📜 lossExampleEquation.png
+|  |  |  |  |- 📜 neuronWithEquation.png
+|  |  |  |  |- 📜 neuron.png
+|  |  |  |  |- 📜 neuralnet.png
+|  |  |  |  |- 📜 sigmoidfunction.png
+|  |  |  |- 📂 wiki_images:
+|  |  |  |  |- 📜 avgpool_maxpool.gif
+|  |  |  |  |- 📜 conv2d2.gif
+|  |  |  |  |- 📜 dropout_diagram.png
+|  |  |  |  |- 📜 batchnorm_diagram.png
+|  |  |  |  |- 📜 tanh_plot.png
+|  |  |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
+|  |  |  |  |- 📜 maxpool2d.gif
+|  |  |  |  |- 📜 tanh_equation.png
+|  |  |  |  |- 📜 conv2d.gif
+|  |  |  |  |- 📜 sigmoid_equation.png
 |  |  |  |- 📜 demo_video.gif : GIF tutorial of a simple classification training session
 |  |  |- 📜 dlp-logo.svg : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
 |  |  |- 📜 robots.txt
-|  |  |- 📜 index.html : Base HTML file that will be initially rendered
 |  |  |- 📜 dlp-logo.png : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
-|  |  |- 📜 dlp-logo.ico : DLP Logo
 |  |  |- 📜 manifest.json : Default React file for choosing icon based on
-|  |- 📜 .eslintrc.json
+|  |  |- 📜 index.html : Base HTML file that will be initially rendered
+|  |  |- 📜 dlp-logo.ico : DLP Logo
 |  |- 📜 package.json
-|  |- 📜 babel.config.js
-|  |- 📜 next.config.js
 |  |- 📜 jest.config.js
+|  |- 📜 .eslintrc.json
+|  |- 📜 tsconfig.json
 |  |- 📜 yarn.lock
 |  |- 📜 .eslintignore
 |  |- 📜 next-env.d.ts
-|  |- 📜 tsconfig.json
+|  |- 📜 babel.config.js
+|  |- 📜 next.config.js
 ```
 

--- a/frontend/src/common/redux/userLogin.ts
+++ b/frontend/src/common/redux/userLogin.ts
@@ -11,6 +11,7 @@ import {
   GoogleAuthProvider,
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
+  signInWithPopup,
   signInWithRedirect,
   signOut,
   updateEmail,
@@ -290,7 +291,8 @@ export const signInViaGoogleRedirect = createAsyncThunk<
 >("currentUser/signInViaGoogle", async (_, thunkAPI) => {
   try {
     const googleProvider = new GoogleAuthProvider();
-    await signInWithRedirect(auth, googleProvider);
+    await signInWithPopup(auth, googleProvider);
+    //await signInWithRedirect(auth, googleProvider);
     return;
   } catch (e) {
     if (e instanceof FirebaseError) {
@@ -308,7 +310,9 @@ export const signInViaGithubRedirect = createAsyncThunk<
   try {
     const githubProvider = new GithubAuthProvider();
     storage.setItem("expect-user", "true");
-    await signInWithRedirect(auth, githubProvider);
+    await signInWithPopup(auth, githubProvider);
+    //await signInWithRedirect(auth, githubProvider);
+    //TODO: Replace with signInWithRedirect: https://firebase.google.com/docs/auth/web/redirect-best-practices
     return;
   } catch (e) {
     if (e instanceof FirebaseError) {

--- a/frontend/src/common/redux/userLogin.ts
+++ b/frontend/src/common/redux/userLogin.ts
@@ -353,7 +353,7 @@ export const fetchUserProgressData = createAsyncThunk<
 
 export const currentUserSlice = createSlice({
   name: "currentUser",
-  initialState: { user: "pending" } as UserState,
+  initialState: { user: undefined } as UserState,
   reducers: {
     setCurrentUser: (
       state,

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -8,14 +8,12 @@ import { Provider } from "react-redux";
 import { setCurrentUser } from "@/common/redux/userLogin";
 import { auth } from "@/common/utils/firebase";
 import store from "@/common/redux/store";
-import { useAppDispatch, useAppSelector } from "@/common/redux/hooks";
+import { useAppDispatch } from "@/common/redux/hooks";
 import { ToastContainer } from "react-toastify";
 
 const FirebaseAuthState = () => {
   const dispatch = useAppDispatch();
-  const user = useAppSelector((state) => state.currentUser.user);
   useEffect(() => {
-    const expectUser = storage.getItem("expect-user");
     auth.onAuthStateChanged((firebaseUser) => {
       if (firebaseUser && firebaseUser.email && firebaseUser.displayName) {
         dispatch(

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -8,28 +8,16 @@ import { Provider } from "react-redux";
 import { setCurrentUser } from "@/common/redux/userLogin";
 import { auth } from "@/common/utils/firebase";
 import store from "@/common/redux/store";
-import storage from "local-storage-fallback";
 import { useAppDispatch, useAppSelector } from "@/common/redux/hooks";
 import { ToastContainer } from "react-toastify";
 
 const FirebaseAuthState = () => {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.currentUser.user);
-  const [pendingUser, setPendingUser] = React.useState<
-    "PENDING" | "RESET" | "DONE"
-  >("PENDING");
   useEffect(() => {
     const expectUser = storage.getItem("expect-user");
-    if (expectUser) {
-      setTimeout(() => {
-        setPendingUser("RESET");
-      }, 5000);
-    } else {
-      setPendingUser("RESET");
-    }
     auth.onAuthStateChanged((firebaseUser) => {
       if (firebaseUser && firebaseUser.email && firebaseUser.displayName) {
-        storage.setItem("expect-user", "true");
         dispatch(
           setCurrentUser({
             email: firebaseUser.email,
@@ -39,21 +27,10 @@ const FirebaseAuthState = () => {
           })
         );
       } else if (firebaseUser == null) {
-        storage.removeItem("expect-user");
         dispatch(setCurrentUser(undefined));
       }
     });
   }, []);
-
-  useEffect(() => {
-    if (pendingUser === "RESET") {
-      if (user === "pending") {
-        storage.removeItem("expect-user");
-        dispatch(setCurrentUser(undefined));
-      }
-      setPendingUser("DONE");
-    }
-  }, [pendingUser, user]);
   return <></>;
 };
 const App = ({ Component, pageProps }: AppProps) => {


### PR DESCRIPTION
# Fix Authentication

**What user problem are we solving?**
Signing In With Github didn't work on Firefox or Safari.

**What solution does this PR provide?**
This provides a temporary fix of signing in with popup instead of redirects. The popup method is ok, but there is also the chance where some setting in a user's browser prevents the popup from appearing. 

My guess for why signing in via redirects didn't work is that right now all of firebase's signinwithredirect methods utilize third-party cookies, which are gradually being deprecated.

There seems a growing standard for browsers to use FedCM for identity federation instead: [https://github.com/fedidcg/FedCM/blob/main/explainer.md](https://github.com/fedidcg/FedCM/blob/main/explainer.md). FedCM however seems really new (I asked ChatGPT and it had no idea what it is), and doesn't have support for all of the major browsers yet (mainly firefox and safari), but it seems like those two also plan to support FedCM in the future. 

This is what firebase suggests as fixes to this problem in the meantime: [https://firebase.google.com/docs/auth/web/redirect-best-practices](https://firebase.google.com/docs/auth/web/redirect-best-practices).

I chose the signInWithPopup option in the website above since it was the simplest, but for production we could try out the reverse proxy option using nginx if we want to keep redirects for prod.

**Testing Methodology**
Signing in with github and google works now in firefox and safari and chrome.

**Any other considerations**