### PR TITLE
fix codeowners using github org project-leads team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # the contributors all will be requested for
 # review when someone opens a pull request.
 
-* @DSGT-DLP/project-lead
+* @DSGT-DLP/project-lead 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # the contributors all will be requested for
 # review when someone opens a pull request.
 
-* @DSGT-DLP/project-leads
+* @DSGT-DLP/project-lead

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # the contributors all will be requested for
 # review when someone opens a pull request.
 
-* @karkir0003 @farisdurrani @dwu359
+* @DSGT-DLP/project-leads


### PR DESCRIPTION
# Update CODEOWNERS
**What user problem are we solving?**
We created a github team to store project leads github username. We should update the CODEOWNERS file to reflect that for any file changed, the project-leads team is pinged
**What solution does this PR provide?**
The update to the above problem
**Testing Methodology**
We will test this when the next PR gets created

**Any other considerations**
N/A