### PR TITLE
pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 # Title of Pull Request HERE
 
+Github Issue Number Here: <YOUR_GITHUB_ISSUE_NUMBER_HERE (include the hashtag)>
 **What user problem are we solving?**
 
 **What solution does this PR provide?**


### PR DESCRIPTION
# Update PR Template with Reminder to Include Github Issue Number

**What user problem are we solving?**
Reminding developers to include issue number in their PR description in order to link github issue to PR for DLP project board automation to trigger (ie: when PR merged, linked issue automatically marked as closed). 

**What solution does this PR provide?**
Adding a field in the PR template description for PR author to enter the github issue number using the hashtag

**Testing Methodology**
See if developer fills out the field in the upcoming PRs

**Any other considerations**
N/A