### PR TITLE
trainspace run dynamo table

### DIFF
--- a/.github/Architecture.md
+++ b/.github/Architecture.md
@@ -4,220 +4,220 @@
 
 ```
 📦 backend
-|  |- 📂 dl:
-|  |  |- 📜 dl_model_parser.py : parse the user specified pytorch model
-|  |  |- 📜 dl_trainer.py : train a deep learning model on the dataset
-|  |  |- 📜 __init__.py
-|  |  |- 📜 dl_model.py : torch model based on user specifications from drag and drop
-|  |  |- 📜 detection.py
-|  |  |- 📜 dl_eval.py : Evaluation functions for deep learning models in Pytorch (eg: accuracy, loss, etc)
-|  |- 📂 ml:
-|  |  |- 📜 ml_trainer.py : train a classical machine learning learning model on the dataset
-|  |  |- 📜 ml_model_parser.py
-|  |  |- 📜 __init__.py
-|  |- 📂 common:
-|  |  |- 📜 optimizer.py : what optimizer to use (ie: SGD or Adam for now)
-|  |  |- 📜 dataset.py : read in the dataset through URL or file upload
-|  |  |- 📜 loss_functions.py : loss function enum
-|  |  |- 📜 __init__.py
-|  |  |- 📜 preprocessing.py
-|  |  |- 📜 constants.py : list of helpful constants
-|  |  |- 📜 ai_drive.py
-|  |  |- 📜 default_datasets.py : store logic to load in default datasets from scikit-learn
-|  |  |- 📜 utils.py : utility functions that could be helpful
-|  |  |- 📜 email_notifier.py : Endpoint to send email notification of training results via API Gateway + AWS SES
-|  |  |- 📜 kernel.py
 |  |- 📂 aws_helpers:
 |  |  |- 📂 dynamo_db_utils:
+|  |  |  |- 📜 trainspace_db.py
+|  |  |  |- 📜 constants.py : list of helpful constants
+|  |  |  |- 📜 userprogress_db.py
 |  |  |  |- 📜 DynamoUnitTests.md
 |  |  |  |- 📜 dynamo_db_utils.py
-|  |  |  |- 📜 constants.py : list of helpful constants
-|  |  |  |- 📜 trainspace_db.py
-|  |  |  |- 📜 userprogress_db.py
 |  |  |- 📜 __init__.py
-|  |- 📜 epoch_times.csv
+|  |- 📂 ml:
+|  |  |- 📜 ml_model_parser.py
+|  |  |- 📜 __init__.py
+|  |  |- 📜 ml_trainer.py : train a classical machine learning learning model on the dataset
+|  |- 📂 common:
+|  |  |- 📜 loss_functions.py : loss function enum
+|  |  |- 📜 default_datasets.py : store logic to load in default datasets from scikit-learn
+|  |  |- 📜 dataset.py : read in the dataset through URL or file upload
+|  |  |- 📜 constants.py : list of helpful constants
+|  |  |- 📜 utils.py : utility functions that could be helpful
+|  |  |- 📜 __init__.py
+|  |  |- 📜 preprocessing.py
+|  |  |- 📜 ai_drive.py
+|  |  |- 📜 kernel.py
+|  |  |- 📜 email_notifier.py : Endpoint to send email notification of training results via API Gateway + AWS SES
+|  |  |- 📜 optimizer.py : what optimizer to use (ie: SGD or Adam for now)
+|  |- 📂 dl:
+|  |  |- 📜 dl_eval.py : Evaluation functions for deep learning models in Pytorch (eg: accuracy, loss, etc)
+|  |  |- 📜 dl_model.py : torch model based on user specifications from drag and drop
+|  |  |- 📜 __init__.py
+|  |  |- 📜 dl_trainer.py : train a deep learning model on the dataset
+|  |  |- 📜 dl_model_parser.py : parse the user specified pytorch model
+|  |  |- 📜 detection.py
 |  |- 📜 app.py : run the backend (entrypoint script)
-|  |- 📜 __init__.py
-|  |- 📜 pyproject.toml
-|  |- 📜 data.csv : data csv file for use in the playground
 |  |- 📜 poetry.lock
+|  |- 📜 epoch_times.csv
+|  |- 📜 __init__.py
+|  |- 📜 data.csv : data csv file for use in the playground
 |  |- 📜 middleware.py
+|  |- 📜 pyproject.toml
 ```
 
 ## Frontend Architecture
 
 ```
 📦 frontend
+|  |- 📂 layer_docs:
+|  |  |- 📜 Softmax.md : Doc for Softmax layer
+|  |  |- 📜 Linear.md : Doc for Linear layer
+|  |  |- 📜 ReLU.md : Doc for ReLU later
+|  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
 |  |- 📂 src:
 |  |  |- 📂 features:
-|  |  |  |- 📂 Train:
+|  |  |  |- 📂 LearnMod:
+|  |  |  |  |- 📜 ModulesSideBar.tsx
+|  |  |  |  |- 📜 MCQuestion.tsx
+|  |  |  |  |- 📜 ClassCard.tsx
+|  |  |  |  |- 📜 ImageComponent.tsx
+|  |  |  |  |- 📜 FRQuestion.tsx
+|  |  |  |  |- 📜 LearningModulesContent.tsx
+|  |  |  |  |- 📜 Exercise.tsx
+|  |  |  |- 📂 Dashboard:
 |  |  |  |  |- 📂 redux:
-|  |  |  |  |  |- 📜 trainspaceSlice.ts
-|  |  |  |  |  |- 📜 trainspaceApi.ts
+|  |  |  |  |  |- 📜 dashboardApi.ts
+|  |  |  |  |- 📂 components:
+|  |  |  |  |  |- 📜 TrainBarChart.tsx
+|  |  |  |  |  |- 📜 TrainDoughnutChart.tsx
+|  |  |  |  |  |- 📜 TrainDataGrid.tsx
+|  |  |  |- 📂 Train:
 |  |  |  |  |- 📂 features:
 |  |  |  |  |  |- 📂 Tabular:
 |  |  |  |  |  |  |- 📂 redux:
-|  |  |  |  |  |  |  |- 📜 tabularApi.ts
 |  |  |  |  |  |  |  |- 📜 tabularActions.ts
-|  |  |  |  |  |  |- 📂 constants:
-|  |  |  |  |  |  |  |- 📜 tabularConstants.ts
-|  |  |  |  |  |  |- 📂 types:
-|  |  |  |  |  |  |  |- 📜 tabularTypes.ts
+|  |  |  |  |  |  |  |- 📜 tabularApi.ts
 |  |  |  |  |  |  |- 📂 components:
 |  |  |  |  |  |  |  |- 📜 TabularReviewStep.tsx
 |  |  |  |  |  |  |  |- 📜 TabularDatasetStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularParametersStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularTrainspace.tsx
 |  |  |  |  |  |  |  |- 📜 TabularFlow.tsx
+|  |  |  |  |  |  |  |- 📜 TabularTrainspace.tsx
+|  |  |  |  |  |  |  |- 📜 TabularParametersStep.tsx
+|  |  |  |  |  |  |- 📂 types:
+|  |  |  |  |  |  |  |- 📜 tabularTypes.ts
+|  |  |  |  |  |  |- 📂 constants:
+|  |  |  |  |  |  |  |- 📜 tabularConstants.ts
 |  |  |  |  |  |  |- 📜 index.ts
 |  |  |  |  |  |- 📂 Image:
 |  |  |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |  |  |- 📜 imageActions.ts
 |  |  |  |  |  |  |  |- 📜 imageApi.ts
-|  |  |  |  |  |  |- 📂 constants:
-|  |  |  |  |  |  |  |- 📜 imageConstants.ts
-|  |  |  |  |  |  |- 📂 types:
-|  |  |  |  |  |  |  |- 📜 imageTypes.ts
 |  |  |  |  |  |  |- 📂 components:
-|  |  |  |  |  |  |  |- 📜 ImageParametersStep.tsx
-|  |  |  |  |  |  |  |- 📜 ImageFlow.tsx
+|  |  |  |  |  |  |  |- 📜 ImageDatasetStep.tsx
 |  |  |  |  |  |  |  |- 📜 ImageTrainspace.tsx
 |  |  |  |  |  |  |  |- 📜 ImageReviewStep.tsx
-|  |  |  |  |  |  |  |- 📜 ImageDatasetStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageParametersStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageFlow.tsx
+|  |  |  |  |  |  |- 📂 types:
+|  |  |  |  |  |  |  |- 📜 imageTypes.ts
+|  |  |  |  |  |  |- 📂 constants:
+|  |  |  |  |  |  |  |- 📜 imageConstants.ts
 |  |  |  |  |  |  |- 📜 index.ts
-|  |  |  |  |- 📂 constants:
-|  |  |  |  |  |- 📜 trainConstants.ts
-|  |  |  |  |- 📂 types:
-|  |  |  |  |  |- 📜 trainTypes.ts
+|  |  |  |  |- 📂 redux:
+|  |  |  |  |  |- 📜 trainspaceApi.ts
+|  |  |  |  |  |- 📜 trainspaceSlice.ts
 |  |  |  |  |- 📂 components:
-|  |  |  |  |  |- 📜 TrainspaceLayout.tsx
 |  |  |  |  |  |- 📜 DatasetStepLayout.tsx
 |  |  |  |  |  |- 📜 CreateTrainspace.tsx
+|  |  |  |  |  |- 📜 TrainspaceLayout.tsx
+|  |  |  |  |- 📂 types:
+|  |  |  |  |  |- 📜 trainTypes.ts
+|  |  |  |  |- 📂 constants:
+|  |  |  |  |  |- 📜 trainConstants.ts
 |  |  |  |- 📂 Feedback:
 |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |- 📜 feedbackApi.ts
 |  |  |  |- 📂 OpenAi:
 |  |  |  |  |- 📜 openAiUtils.ts
-|  |  |  |- 📂 LearnMod:
-|  |  |  |  |- 📜 ModulesSideBar.tsx
-|  |  |  |  |- 📜 ImageComponent.tsx
-|  |  |  |  |- 📜 MCQuestion.tsx
-|  |  |  |  |- 📜 ClassCard.tsx
-|  |  |  |  |- 📜 FRQuestion.tsx
-|  |  |  |  |- 📜 Exercise.tsx
-|  |  |  |  |- 📜 LearningModulesContent.tsx
-|  |  |  |- 📂 Dashboard:
-|  |  |  |  |- 📂 redux:
-|  |  |  |  |  |- 📜 dashboardApi.ts
-|  |  |  |  |- 📂 components:
-|  |  |  |  |  |- 📜 TrainDoughnutChart.tsx
-|  |  |  |  |  |- 📜 TrainDataGrid.tsx
-|  |  |  |  |  |- 📜 TrainBarChart.tsx
-|  |  |- 📂 common:
-|  |  |  |- 📂 redux:
-|  |  |  |  |- 📜 backendApi.ts
-|  |  |  |  |- 📜 userLogin.ts
-|  |  |  |  |- 📜 train.ts
-|  |  |  |  |- 📜 store.ts
-|  |  |  |  |- 📜 hooks.ts
-|  |  |  |- 📂 styles:
-|  |  |  |  |- 📜 globals.css
-|  |  |  |  |- 📜 Home.module.css
-|  |  |  |- 📂 components:
-|  |  |  |  |- 📜 ClientOnlyPortal.tsx
-|  |  |  |  |- 📜 EmailInput.tsx
-|  |  |  |  |- 📜 NavBarMain.tsx
-|  |  |  |  |- 📜 Spacer.tsx
-|  |  |  |  |- 📜 HtmlTooltip.tsx
-|  |  |  |  |- 📜 TitleText.tsx
-|  |  |  |  |- 📜 DlpTooltip.tsx
-|  |  |  |  |- 📜 Footer.tsx
-|  |  |  |- 📂 utils:
-|  |  |  |  |- 📜 dndHelpers.ts
-|  |  |  |  |- 📜 firebase.ts
-|  |  |  |  |- 📜 dateFormat.ts
 |  |  |- 📂 pages:
 |  |  |  |- 📂 train:
 |  |  |  |  |- 📜 [train_space_id].tsx
 |  |  |  |  |- 📜 index.tsx
-|  |  |  |- 📜 _document.tsx
-|  |  |  |- 📜 dashboard.tsx
-|  |  |  |- 📜 _app.tsx
 |  |  |  |- 📜 LearnContent.tsx
-|  |  |  |- 📜 forgot.tsx
-|  |  |  |- 📜 learn.tsx
-|  |  |  |- 📜 settings.tsx
 |  |  |  |- 📜 feedback.tsx
-|  |  |  |- 📜 about.tsx
-|  |  |  |- 📜 login.tsx
+|  |  |  |- 📜 dashboard.tsx
+|  |  |  |- 📜 learn.tsx
 |  |  |  |- 📜 wiki.tsx
+|  |  |  |- 📜 forgot.tsx
+|  |  |  |- 📜 about.tsx
+|  |  |  |- 📜 _app.tsx
+|  |  |  |- 📜 login.tsx
+|  |  |  |- 📜 _document.tsx
+|  |  |  |- 📜 settings.tsx
+|  |  |- 📂 common:
+|  |  |  |- 📂 styles:
+|  |  |  |  |- 📜 Home.module.css
+|  |  |  |  |- 📜 globals.css
+|  |  |  |- 📂 redux:
+|  |  |  |  |- 📜 hooks.ts
+|  |  |  |  |- 📜 train.ts
+|  |  |  |  |- 📜 store.ts
+|  |  |  |  |- 📜 backendApi.ts
+|  |  |  |  |- 📜 userLogin.ts
+|  |  |  |- 📂 components:
+|  |  |  |  |- 📜 DlpTooltip.tsx
+|  |  |  |  |- 📜 Footer.tsx
+|  |  |  |  |- 📜 HtmlTooltip.tsx
+|  |  |  |  |- 📜 NavBarMain.tsx
+|  |  |  |  |- 📜 Spacer.tsx
+|  |  |  |  |- 📜 EmailInput.tsx
+|  |  |  |  |- 📜 TitleText.tsx
+|  |  |  |  |- 📜 ClientOnlyPortal.tsx
+|  |  |  |- 📂 utils:
+|  |  |  |  |- 📜 dndHelpers.ts
+|  |  |  |  |- 📜 firebase.ts
+|  |  |  |  |- 📜 dateFormat.ts
 |  |  |- 📂 backend_outputs:
-|  |  |  |- 📜 model.pkl
 |  |  |  |- 📜 model.pt : Last model.pt output
 |  |  |  |- 📜 my_deep_learning_model.onnx : Last ONNX file output
+|  |  |  |- 📜 model.pkl
+|  |  |- 📜 next-env.d.ts
 |  |  |- 📜 iris.csv : Sample CSV data
 |  |  |- 📜 constants.ts
 |  |  |- 📜 GlobalStyle.ts
-|  |  |- 📜 next-env.d.ts
 |  |- 📂 public:
 |  |  |- 📂 images:
 |  |  |  |- 📂 wiki_images:
-|  |  |  |  |- 📜 maxpool2d.gif
-|  |  |  |  |- 📜 tanh_plot.png
-|  |  |  |  |- 📜 avgpool_maxpool.gif
+|  |  |  |  |- 📜 sigmoid_equation.png
 |  |  |  |  |- 📜 batchnorm_diagram.png
-|  |  |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
+|  |  |  |  |- 📜 maxpool2d.gif
 |  |  |  |  |- 📜 conv2d.gif
 |  |  |  |  |- 📜 conv2d2.gif
-|  |  |  |  |- 📜 tanh_equation.png
 |  |  |  |  |- 📜 dropout_diagram.png
-|  |  |  |  |- 📜 sigmoid_equation.png
+|  |  |  |  |- 📜 tanh_equation.png
+|  |  |  |  |- 📜 avgpool_maxpool.gif
+|  |  |  |  |- 📜 tanh_plot.png
+|  |  |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
 |  |  |  |- 📂 learn_mod_images:
-|  |  |  |  |- 📜 ReLUactivation.png
-|  |  |  |  |- 📜 binarystepactivation.png
-|  |  |  |  |- 📜 lossExampleEquation.png
-|  |  |  |  |- 📜 sigmoidactivation.png
-|  |  |  |  |- 📜 sigmoidfunction.png
-|  |  |  |  |- 📜 robotImage.jpg
-|  |  |  |  |- 📜 lossExample.png
-|  |  |  |  |- 📜 lossExampleTable.png
-|  |  |  |  |- 📜 neuronWithEquation.png
-|  |  |  |  |- 📜 LeakyReLUactivation.png
-|  |  |  |  |- 📜 neuron.png
 |  |  |  |  |- 📜 neuralnet.png
+|  |  |  |  |- 📜 robotImage.jpg
+|  |  |  |  |- 📜 ReLUactivation.png
+|  |  |  |  |- 📜 neuronWithEquation.png
 |  |  |  |  |- 📜 tanhactivation.png
+|  |  |  |  |- 📜 sigmoidactivation.png
+|  |  |  |  |- 📜 binarystepactivation.png
+|  |  |  |  |- 📜 lossExampleTable.png
+|  |  |  |  |- 📜 sigmoidfunction.png
+|  |  |  |  |- 📜 neuron.png
+|  |  |  |  |- 📜 LeakyReLUactivation.png
+|  |  |  |  |- 📜 lossExample.png
+|  |  |  |  |- 📜 lossExampleEquation.png
 |  |  |  |- 📂 logos:
 |  |  |  |  |- 📂 dlp_branding:
-|  |  |  |  |  |- 📜 dlp-logo.svg : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
 |  |  |  |  |  |- 📜 dlp-logo.png : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
+|  |  |  |  |  |- 📜 dlp-logo.svg : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
 |  |  |  |  |- 📜 dsgt-logo-dark.png
-|  |  |  |  |- 📜 github.png
 |  |  |  |  |- 📜 google.png
+|  |  |  |  |- 📜 react-logo.png
+|  |  |  |  |- 📜 flask-logo.png
+|  |  |  |  |- 📜 pytorch-logo.png
+|  |  |  |  |- 📜 aws-logo.png
+|  |  |  |  |- 📜 dsgt-logo-light.png
+|  |  |  |  |- 📜 github.png
+|  |  |  |  |- 📜 pandas-logo.png
 |  |  |  |  |- 📜 python-logo.png
 |  |  |  |  |- 📜 dsgt-logo-white-back.png
-|  |  |  |  |- 📜 pandas-logo.png
-|  |  |  |  |- 📜 aws-logo.png
-|  |  |  |  |- 📜 flask-logo.png
-|  |  |  |  |- 📜 react-logo.png
-|  |  |  |  |- 📜 dsgt-logo-light.png
-|  |  |  |  |- 📜 pytorch-logo.png
 |  |  |  |- 📜 demo_video.gif : GIF tutorial of a simple classification training session
-|  |  |- 📜 dlp-logo.ico : DLP Logo
 |  |  |- 📜 index.html : Base HTML file that will be initially rendered
-|  |  |- 📜 manifest.json : Default React file for choosing icon based on
 |  |  |- 📜 robots.txt
-|  |- 📂 layer_docs:
-|  |  |- 📜 Softmax.md : Doc for Softmax layer
-|  |  |- 📜 Linear.md : Doc for Linear layer
-|  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
-|  |  |- 📜 ReLU.md : Doc for ReLU later
-|  |- 📜 .eslintrc.json
-|  |- 📜 .eslintignore
+|  |  |- 📜 manifest.json : Default React file for choosing icon based on
+|  |  |- 📜 dlp-logo.ico : DLP Logo
 |  |- 📜 package.json
-|  |- 📜 jest.config.js
-|  |- 📜 tsconfig.json
-|  |- 📜 next.config.js
-|  |- 📜 yarn.lock
+|  |- 📜 .eslintrc.json
 |  |- 📜 next-env.d.ts
+|  |- 📜 tsconfig.json
+|  |- 📜 yarn.lock
+|  |- 📜 .eslintignore
+|  |- 📜 next.config.js
+|  |- 📜 jest.config.js
 ```
 

--- a/serverless/stacks/AppStack.ts
+++ b/serverless/stacks/AppStack.ts
@@ -1,4 +1,4 @@
-import { Api, Bucket, StackContext } from "sst/constructs";
+import { Api, Bucket, StackContext, Table } from "sst/constructs";
 import { Bucket as s3Bucket } from "aws-cdk-lib/aws-s3";
 
 export function AppStack({ stack }: StackContext) {
@@ -9,6 +9,26 @@ export function AppStack({ stack }: StackContext) {
         "i-dlp-upload-bucket",
         "arn:aws:s3:::dlp-upload-bucket"
       ),
+    },
+  });
+  const trainspaceRunTable = new Table(stack, "trainspace-run", {
+    fields: {
+      runId: "string",
+      trainspaceId: "string",
+      userId: "string",
+      timestamp: "string",
+      resultCsvUri: "string",
+      modelPtUri: "string",
+      onnxUri: "string",
+      confusionMatrixUri: "string",
+      aucRocUri: "string"
+    },
+    primaryIndex: {
+      partitionKey: "runId",
+    },
+    globalIndexes: {
+      "TrainspaceIndex": { partitionKey: "trainspaceId", sortKey: "timestamp"},
+      "UserIndex": {partitionKey: "userId"}
     },
   });
   const api = new Api(stack, "Api", {

--- a/serverless/stacks/AppStack.ts
+++ b/serverless/stacks/AppStack.ts
@@ -70,5 +70,8 @@ export function AppStack({ stack }: StackContext) {
     GetUserDatasetColumnsFunctionName:
       api.getFunction("GET /datasets/user/{type}/{filename}/columns")
         ?.functionName ?? "",
+    TrainspaceRunTableName: {
+      value: trainspaceRunTable.tableName
+    }
   });
 }


### PR DESCRIPTION
# Trainspace Run DynamoDB Table

Github Issue Number Here: #995 
**What user problem are we solving?**
Creation of a separate trainspace run DynamoDB table to track a user's trainspace run attempts. This table lets us track a user's trainspace run attempt and store the S3 links to the result files. 

**What solution does this PR provide?**
SST resource of the trainspace run DynamoDB table stored in an infrastructure as code framework

**Testing Methodology**
Ran a dev deploy and took a look at the created dynamodb table to see if the partition key and global secondary indices are correct. We will also need to actually write data to the table in order to test that the CRUD operations work with this new table given valid data.

**Any other considerations**
Decide on how we can configure a Time to live (TTL) setting for data retention policy purposes