### PR TITLE
Update getColumnsFromDataset endpoint to SST

### DIFF
--- a/frontend/src/features/Train/redux/trainspaceApi.ts
+++ b/frontend/src/features/Train/redux/trainspaceApi.ts
@@ -51,14 +51,12 @@ const trainspaceApi = backendApi
             message: string;
           };
           const getObjUrl = getObj.data;
-          const formData = new FormData();
-          formData.append("file", file);
           const uploadQuery = fetchBaseQuery();
           const response = await uploadQuery(
             {
               url: getObjUrl,
               method: "PUT",
-              body: formData,
+              body: file,
             },
             _,
             __
@@ -78,7 +76,7 @@ const trainspaceApi = backendApi
         query: ({ dataSource, dataset }) => ({
           url: dataset.isDefaultDataset
             ? `/api/training/datasets/default/${dataset.name}/columns`
-            : "/api/dataset/getColumnsFromDatasetFile",
+            : `/api/lambda/datasets/user/${dataSource}/${dataset.name}/columns`,
           method: "GET",
           /*body: {
             data_source: dataSource.toLowerCase(),


### PR DESCRIPTION
Update getColumnsFromDataset endpoint to SST

Github Issue Number Here: #980

**What user problem are we solving?**
Users can now read and select the the parsed columns from their uploaded dataset. 

**What solution does this PR provide?**
This solution changes the URL for the getColumnsFromDataset GET request to point to our new SST endpoint that handles parsing for user uploaded files.

**Testing Methodology**
Tested upload/file read with two different CSV files that had designated column names. I examined network logs and response codes while doing so, everything seems to be fine. See video below.


https://github.com/DSGT-DLP/Deep-Learning-Playground/assets/7332345/11986912-55dc-4aa7-a0ef-6a57d5418884


**Any other considerations**
Apparently when running a PUT request for the presigned URL upload, the body must contain the raw file data itself and not as FormData. This important to keep note for future presigned URL uploads. The documentation I found through Googling didn't really mention this (thanks ChatGPT for the help). 