### PR TITLE
Migrate Image Training Endpoint to Django

### DIFF
--- a/training/training/core/criterion.py
+++ b/training/training/core/criterion.py
@@ -46,7 +46,7 @@ class CELossHandler(CriterionHandler):
     def _compute_loss(self, output, labels):
         output = torch.reshape(
             output,
-            (output.shape[0], output.shape[2]),
+            (output.shape[0], output.shape[-1]),
         )
         labels = labels.squeeze_()
         return nn.CrossEntropyLoss(reduction="mean")(output, labels.long())

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -20,7 +20,7 @@ import shutil
 
 
 class TrainTestDatasetCreator(ABC):
-    "Creator that creates train and test PyTorch datasets"
+    "Creator that creates train and test PyTorch datasets from a given dataset"
 
     @abstractmethod
     def createTrainDataset(self) -> Dataset:

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -120,7 +120,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
         test_transform: None,
         batch_size: int = 32,
         shuffle: bool = True,
-        hello: str = "world"
+        hello: str = "world",
     ):
         if dataset_name not in DefaultImageDatasets.__members__:
             raise Exception(

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -113,7 +113,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
     def __init__(
         self,
         dataset_name: str,
-        train_tarnsform: None,
+        train_transform: None,
         test_transform: None,
         batch_size: int = 32,
         shuffle: bool = True,
@@ -122,7 +122,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
             raise Exception(
                 f"The {dataset_name} file does not currently exist in our inventory. Please submit a request to the contributors of the repository"
             )
-        self.train_transform = train_tarnsform or transforms.Compose(
+        self.train_transform = train_transform or transforms.Compose(
             [transforms.toTensor()]
         )
         self.test_transform = test_transform or transforms.Compose(
@@ -163,7 +163,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
             drop_last=True,
         )
 
-    def createTestDataset(self):
+    def createTestDataset(self) -> DataLoader:
         return DataLoader(
             self.test_set,
             batch_size=self.batch_size,

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -109,7 +109,7 @@ class DefaultImageDatasets(Enum):
     MNIST = "MNIST"
     FASHION_MNIST = "FashionMNIST"
     KMNIST = "KMNIST"
-    CIFAR = "CIFAR10"
+    CIFAR10 = "CIFAR10"
 
 
 class ImageDefaultDatasetCreator(TrainTestDatasetCreator):

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -127,20 +127,22 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
             )
 
         self.dataset_dir = "./training/image_data_uploads"
-
         self.train_transform = train_transform or transforms.Compose(
-            [transforms.toTensor()]
+            [transforms.ToTensor()]
         )
+        
         self.test_transform = test_transform or transforms.Compose(
-            [transforms.toTensor()]
+            [transforms.ToTensor()]
         )
         self.batch_size = batch_size
         self.shuffle = shuffle
 
         # Ensure the directory exists
         os.makedirs(self.dataset_dir, exist_ok=True)
-
+        print(f'train transform: {train_transform}')
+        print(f'test transform: {test_transform}')
         # Load the datasets
+        
         self.train_set = datasets.__dict__[dataset_name](
             root=self.dataset_dir,
             train=True,

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -102,38 +102,74 @@ class SklearnDatasetCreator(TrainTestDatasetCreator):
             raise Exception("Category list not available")
         return self._category_list
 
+
 class DefaultImageDatasets(Enum):
     MNIST = "MNIST"
     FASHION_MNIST = "FashionMNIST"
     KMNIST = "KMNIST"
-class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
 
+
+class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
     def __init__(
-        self, 
-        dataset_name:str, 
-        train_tarnsform:None,
-        test_transform:None,
-        batch_size: int = 32, 
+        self,
+        dataset_name: str,
+        train_tarnsform: None,
+        test_transform: None,
+        batch_size: int = 32,
         shuffle: bool = True,
     ):
         if dataset_name not in DefaultImageDatasets.__members__:
-            raise Exception(f"The {dataset_name} file does not currently exist in our inventory. Please submit a request to the contributors of the repository")
-        self.train_transform = train_tarnsform or transforms.Compose([transforms.toTensor()])
-        self.test_transform = test_transform or transforms.Compose([transforms.toTensor()])
+            raise Exception(
+                f"The {dataset_name} file does not currently exist in our inventory. Please submit a request to the contributors of the repository"
+            )
+        self.train_transform = train_tarnsform or transforms.Compose(
+            [transforms.toTensor()]
+        )
+        self.test_transform = test_transform or transforms.Compose(
+            [transforms.toTensor()]
+        )
         self.batch_size = batch_size
         self.shuffle = shuffle
 
-        self.train_set = datasets.__dict__[dataset_name](root='./backend/image_data_uploads', train=True, download=True, transform=self.train_transform)
-        self.test_set = datasets.__dict__[dataset_name](root='./backend/image_data_uploads', train=False, download=True, transform=self.test_transform)
-
+        self.train_set = datasets.__dict__[dataset_name](
+            root="./backend/image_data_uploads",
+            train=True,
+            download=True,
+            transform=self.train_transform,
+        )
+        self.test_set = datasets.__dict__[dataset_name](
+            root="./backend/image_data_uploads",
+            train=False,
+            download=True,
+            transform=self.test_transform,
+        )
 
     @classmethod
-    def fromDefault(cls, dataset_name: str, train_transform=None, test_transform=None, batch_size: int = 32, shuffle: bool = True):
+    def fromDefault(
+        cls,
+        dataset_name: str,
+        train_transform=None,
+        test_transform=None,
+        batch_size: int = 32,
+        shuffle: bool = True,
+    ):
         return cls(dataset_name, train_transform, test_transform, batch_size, shuffle)
+
     def createTrainDataset(self) -> DataLoader:
-        return DataLoader(self.train_set, batch_size = self.batch_size, shuffle = self.shuffle, drop_last=True)
-    
+        return DataLoader(
+            self.train_set,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            drop_last=True,
+        )
+
     def createTestDataset(self):
-        return DataLoader(self.test_set, batch_size = self.batch_size, shuffle = self.shuffle, drop_last=True)
+        return DataLoader(
+            self.test_set,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            drop_last=True,
+        )
+
     def getCategoryList(self) -> list[str]:
         return self.train_set.classes if hasattr(self.train_set, "classes") else []

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -120,7 +120,6 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
         test_transform: None,
         batch_size: int = 32,
         shuffle: bool = True,
-        hello: str = "world"
     ):
         if dataset_name not in DefaultImageDatasets.__members__:
             raise Exception(
@@ -141,6 +140,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
         # Ensure the directory exists
         os.makedirs(self.dataset_dir, exist_ok=True)
 
+        # Load the datasets
         self.train_set = datasets.__dict__[dataset_name](
             root=self.dataset_dir,
             train=True,
@@ -167,7 +167,11 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
 
     def delete_datasets_from_directory(self):
         if os.path.exists(self.dataset_dir):
-            shutil.rmtree(self.dataset_dir)
+            try:
+                shutil.rmtree(self.dataset_dir)
+                print(f"Successfully deleted {self.dataset_dir}")
+            except Exception as e:
+                print(f"Failed to delete {self.dataset_dir} with error: {e}")
 
     def createTrainDataset(self) -> DataLoader:
         train_loader = DataLoader(
@@ -176,7 +180,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
             shuffle=self.shuffle,
             drop_last=True,
         )
-        self.delete_datasets_from_directory()
+        self.delete_datasets_from_directory() # Delete datasets after loading
         return train_loader
 
     def createTestDataset(self) -> DataLoader:
@@ -186,7 +190,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
             shuffle=self.shuffle,
             drop_last=True,
         )
-        self.delete_datasets_from_directory()
+        self.delete_datasets_from_directory() # Delete datasets after loading
         return test_loader
 
     def getCategoryList(self) -> list[str]:

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -12,6 +12,9 @@ import pandas as pd
 import torch
 from torch.utils.data import Dataset
 from torch.autograd import Variable
+from torchvision import datasets, transforms
+from torch.util.data import DataLoader, random_split
+from enum import Enum
 
 
 class TrainTestDatasetCreator(ABC):
@@ -98,3 +101,39 @@ class SklearnDatasetCreator(TrainTestDatasetCreator):
         if self._category_list is None:
             raise Exception("Category list not available")
         return self._category_list
+
+class DefaultImageDatasets(Enum):
+    MNIST = "MNIST"
+    FASHION_MNIST = "FashionMNIST"
+    KMNIST = "KMNIST"
+class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
+
+    def __init__(
+        self, 
+        dataset_name:str, 
+        train_tarnsform:None,
+        test_transform:None,
+        batch_size: int = 32, 
+        shuffle: bool = True,
+    ):
+        if dataset_name not in DefaultImageDatasets.__members__:
+            raise Exception(f"The {dataset_name} file does not currently exist in our inventory. Please submit a request to the contributors of the repository")
+        self.train_transform = train_tarnsform or transforms.Compose([transforms.toTensor()])
+        self.test_transform = test_transform or transforms.Compose([transforms.toTensor()])
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+
+        self.train_set = datasets.__dict__[dataset_name](root='./backend/image_data_uploads', train=True, download=True, transform=self.train_transform)
+        self.test_set = datasets.__dict__[dataset_name](root='./backend/image_data_uploads', train=False, download=True, transform=self.test_transform)
+
+
+    @classmethod
+    def fromDefault(cls, dataset_name: str, train_transform=None, test_transform=None, batch_size: int = 32, shuffle: bool = True):
+        return cls(dataset_name, train_transform, test_transform, batch_size, shuffle)
+    def createTrainDataset(self) -> DataLoader:
+        return DataLoader(self.train_set, batch_size = self.batch_size, shuffle = self.shuffle, drop_last=True)
+    
+    def createTestDataset(self):
+        return DataLoader(self.test_set, batch_size = self.batch_size, shuffle = self.shuffle, drop_last=True)
+    def getCategoryList(self) -> list[str]:
+        return self.train_set.classes if hasattr(self.train_set, "classes") else []

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -13,7 +13,7 @@ import torch
 from torch.utils.data import Dataset
 from torch.autograd import Variable
 from torchvision import datasets, transforms
-from torch.util.data import DataLoader, random_split
+from torch.utils.data import DataLoader
 from enum import Enum
 
 
@@ -107,6 +107,7 @@ class DefaultImageDatasets(Enum):
     MNIST = "MNIST"
     FASHION_MNIST = "FashionMNIST"
     KMNIST = "KMNIST"
+    CIFAR = "CIFAR10"
 
 
 class ImageDefaultDatasetCreator(TrainTestDatasetCreator):

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -125,8 +125,8 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
             raise Exception(
                 f"The {dataset_name} file does not currently exist in our inventory. Please submit a request to the contributors of the repository"
             )
-        
-        self.dataset_dir = './training/image_data_uploads'
+
+        self.dataset_dir = "./training/image_data_uploads"
 
         self.train_transform = train_transform or transforms.Compose(
             [transforms.toTensor()]
@@ -137,7 +137,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
         self.batch_size = batch_size
         self.shuffle = shuffle
 
-         # Ensure the directory exists
+        # Ensure the directory exists
         os.makedirs(self.dataset_dir, exist_ok=True)
 
         self.train_set = datasets.__dict__[dataset_name](
@@ -163,13 +163,13 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
         shuffle: bool = True,
     ) -> "ImageDefaultDatasetCreator":
         return cls(dataset_name, train_transform, test_transform, batch_size, shuffle)
-    
+
     def delete_datasets_from_directory(self):
         if os.path.exists(self.dataset_dir):
             shutil.rmtree(self.dataset_dir)
 
     def createTrainDataset(self) -> DataLoader:
-        train_loader =  DataLoader(
+        train_loader = DataLoader(
             self.train_set,
             batch_size=self.batch_size,
             shuffle=self.shuffle,

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -161,7 +161,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
         test_transform=None,
         batch_size: int = 32,
         shuffle: bool = True,
-    ):
+    ) -> "ImageDefaultDatasetCreator":
         return cls(dataset_name, train_transform, test_transform, batch_size, shuffle)
     
     def delete_datasets_from_directory(self):

--- a/training/training/core/dataset.py
+++ b/training/training/core/dataset.py
@@ -120,6 +120,7 @@ class ImageDefaultDatasetCreator(TrainTestDatasetCreator):
         test_transform: None,
         batch_size: int = 32,
         shuffle: bool = True,
+        hello: str = "world"
     ):
         if dataset_name not in DefaultImageDatasets.__members__:
             raise Exception(

--- a/training/training/core/dl_model.py
+++ b/training/training/core/dl_model.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 from typing import TYPE_CHECKING
 
 from training.routes.tabular.schemas import LayerParams
+from training.routes.image.schemas import LayerParams
 
 
 class DLModel(nn.Module):

--- a/training/training/core/dl_model.py
+++ b/training/training/core/dl_model.py
@@ -17,7 +17,9 @@ class DLModel(nn.Module):
         "SIGMOID": nn.Sigmoid,
         "LOGSOFTMAX": nn.LogSoftmax,
         "CONV2D": nn.Conv2d,
-        "DROPOUT": nn.Dropout
+        "DROPOUT": nn.Dropout,
+        "MAXPOOL2D": nn.MaxPool2d,
+        "FLATTEN": nn.Flatten
     }
 
     def __init__(self, layer_list: list[nn.Module]):

--- a/training/training/core/dl_model.py
+++ b/training/training/core/dl_model.py
@@ -16,6 +16,8 @@ class DLModel(nn.Module):
         "SOFTMAX": nn.Softmax,
         "SIGMOID": nn.Sigmoid,
         "LOGSOFTMAX": nn.LogSoftmax,
+        "CONV2D": nn.Conv2d,
+        "DROPOUT": nn.Dropout
     }
 
     def __init__(self, layer_list: list[nn.Module]):

--- a/training/training/core/trainer.py
+++ b/training/training/core/trainer.py
@@ -204,8 +204,6 @@ class ClassificationTrainer(Trainer[ClassificationEpochResult]):
         super()._train_init()
 
     def _train_step(self, inputs: torch.Tensor, labels: torch.Tensor):
-        print(f'input shape: {inputs.shape}')
-        print(f'labels shape: {labels.shape}')
         super()._train_step(inputs, labels)
         self._train_correct += self.compute_correct(self._outputs, labels)
 

--- a/training/training/core/trainer.py
+++ b/training/training/core/trainer.py
@@ -62,6 +62,10 @@ class Trainer(Iterator[T]):
         self.optimizer.zero_grad()  # zero out gradient for each batch
         self.model.forward(inputs)  # make prediction on input
         self._outputs: torch.Tensor = self.model(inputs)  # make prediction on input
+        print('MODEL FORWARD PASS DONE!!!!')
+        print(f'output dim: {self._outputs.shape}')
+        print(f'label dim: {labels.shape}')
+        print(f'loss function used: {self.criterionHandler}')
         loss = self.criterionHandler.compute_loss(self._outputs, labels)
         loss.backward()  # backpropagation
         self.optimizer.step()  # adjust optimizer weights
@@ -200,6 +204,8 @@ class ClassificationTrainer(Trainer[ClassificationEpochResult]):
         super()._train_init()
 
     def _train_step(self, inputs: torch.Tensor, labels: torch.Tensor):
+        print(f'input shape: {inputs.shape}')
+        print(f'labels shape: {labels.shape}')
         super()._train_step(inputs, labels)
         self._train_correct += self.compute_correct(self._outputs, labels)
 

--- a/training/training/core/trainer.py
+++ b/training/training/core/trainer.py
@@ -62,10 +62,6 @@ class Trainer(Iterator[T]):
         self.optimizer.zero_grad()  # zero out gradient for each batch
         self.model.forward(inputs)  # make prediction on input
         self._outputs: torch.Tensor = self.model(inputs)  # make prediction on input
-        print('MODEL FORWARD PASS DONE!!!!')
-        print(f'output dim: {self._outputs.shape}')
-        print(f'label dim: {labels.shape}')
-        print(f'loss function used: {self.criterionHandler}')
         loss = self.criterionHandler.compute_loss(self._outputs, labels)
         loss.backward()  # backpropagation
         self.optimizer.step()  # adjust optimizer weights

--- a/training/training/routes/datasets/default/__init__.py
+++ b/training/training/routes/datasets/default/__init__.py
@@ -1,5 +1,0 @@
-from training.routes.datasets.default.columns import router
-
-
-def get_default_datasets_router():
-    return router

--- a/training/training/routes/image/__init__.py
+++ b/training/training/routes/image/__init__.py
@@ -1,5 +1,0 @@
-from training.routes.image.image import router
-
-
-def get_image_router() -> router:
-    return router

--- a/training/training/routes/image/__init__.py
+++ b/training/training/routes/image/__init__.py
@@ -1,5 +1,5 @@
 from training.routes.image.image import router
 
 
-def get_image_router():
+def get_image_router() -> router:
     return router

--- a/training/training/routes/image/__init__.py
+++ b/training/training/routes/image/__init__.py
@@ -1,0 +1,5 @@
+from training.routes.image.image import router
+
+
+def get_image_router():
+    return router

--- a/training/training/routes/image/image.py
+++ b/training/training/routes/image/image.py
@@ -22,20 +22,6 @@ def imageTrain(request: HttpRequest, imageParams: ImageParams):
         print(vars(dataCreator))
         train_loader = dataCreator.createTrainDataset()
         test_loader = dataCreator.createTestDataset()
-        # train_loader = DataLoader(
-        #     dataCreator.createTrainDataset(),
-        #     batch_size=imageParams.batch_size,
-        #     shuffle=False,
-        #     drop_last=True,
-        # )
-
-        # test_loader = DataLoader(
-        #     dataCreator.createTestDataset(),
-        #     batch_size=imageParams.batch_size,
-        #     shuffle=False,
-        #     drop_last=True,
-        # )
-
         model = DLModel.fromLayerParamsList(imageParams.user_arch)
         print(f'model is: {model}')
         optimizer = getOptimizer(model, imageParams.optimizer_name, 0.05)

--- a/training/training/routes/image/image.py
+++ b/training/training/routes/image/image.py
@@ -12,6 +12,7 @@ from training.core.authenticator import FirebaseAuth
 
 router = Router()
 
+
 @router.post("", auth=FirebaseAuth())
 def imageTrain(request: HttpRequest, imageParams: ImageParams):
     if imageParams.default:

--- a/training/training/routes/image/image.py
+++ b/training/training/routes/image/image.py
@@ -1,0 +1,53 @@
+from typing import Literal, Optional
+from django.http import HttpRequest
+from ninja import Router, Schema
+from training.core.criterion import getCriterionHandler
+from training.core.dl_model import DLModel
+from training.core.datasets import ImageDefaultDatasetCreator
+from torch.utils.data import DataLoader
+from training.core.optimizer import getOptimizer
+from training.core.trainer import ClassificationTrainer
+from training.routes.image.schemas import ImageParams
+from training.core.authenticator import FirebaseAuth
+
+router = Router()
+
+@router.post("", auth=FirebaseAuth())
+def imageTrain(request: HttpRequest, imageParams: ImageParams):
+    if imageParams.default:
+        dataCreator = ImageDefaultDatasetCreator.fromDefault(
+            imageParams.default, imageParams.test_size, imageParams.shuffle
+        )
+        train_loader = DataLoader(
+            dataCreator.createTrainDataset(),
+            batch_size=imageParams.batch_size,
+            shuffle=False,
+            drop_last=True,
+        )
+
+        test_loader = DataLoader(
+            dataCreator.createTestDataset(),
+            batch_size=imageParams.batch_size,
+            shuffle=False,
+            drop_last=True,
+        )
+
+        model = DLModel.fromLayerParamsList(imageParams.user_arch)
+        optimizer = getOptimizer(model, imageParams.optimizer_name, 0.05)
+        criterionHandler = getCriterionHandler(imageParams.criterion)
+        if imageParams.problem_type == "CLASSIFICATION":
+            trainer = ClassificationTrainer(
+                train_loader,
+                test_loader,
+                model,
+                optimizer,
+                criterionHandler,
+                imageParams.epochs,
+                dataCreator.getCategoryList(),
+            )
+            for epoch_result in trainer:
+                print(epoch_result)
+            print(trainer.labels_last_epoch, trainer.y_pred_last_epoch)
+            print(trainer.generate_confusion_matrix())
+            print(trainer.generate_AUC_ROC_CURVE())
+            return trainer.generate_AUC_ROC_CURVE()

--- a/training/training/routes/image/image.py
+++ b/training/training/routes/image/image.py
@@ -3,7 +3,7 @@ from django.http import HttpRequest
 from ninja import Router, Schema
 from training.core.criterion import getCriterionHandler
 from training.core.dl_model import DLModel
-from training.core.datasets import ImageDefaultDatasetCreator
+from training.core.dataset import ImageDefaultDatasetCreator
 from torch.utils.data import DataLoader
 from training.core.optimizer import getOptimizer
 from training.core.trainer import ClassificationTrainer
@@ -17,23 +17,27 @@ router = Router()
 def imageTrain(request: HttpRequest, imageParams: ImageParams):
     if imageParams.default:
         dataCreator = ImageDefaultDatasetCreator.fromDefault(
-            imageParams.default, imageParams.test_size, imageParams.shuffle
+            imageParams.default
         )
-        train_loader = DataLoader(
-            dataCreator.createTrainDataset(),
-            batch_size=imageParams.batch_size,
-            shuffle=False,
-            drop_last=True,
-        )
+        print(vars(dataCreator))
+        train_loader = dataCreator.createTrainDataset()
+        test_loader = dataCreator.createTestDataset()
+        # train_loader = DataLoader(
+        #     dataCreator.createTrainDataset(),
+        #     batch_size=imageParams.batch_size,
+        #     shuffle=False,
+        #     drop_last=True,
+        # )
 
-        test_loader = DataLoader(
-            dataCreator.createTestDataset(),
-            batch_size=imageParams.batch_size,
-            shuffle=False,
-            drop_last=True,
-        )
+        # test_loader = DataLoader(
+        #     dataCreator.createTestDataset(),
+        #     batch_size=imageParams.batch_size,
+        #     shuffle=False,
+        #     drop_last=True,
+        # )
 
         model = DLModel.fromLayerParamsList(imageParams.user_arch)
+        print(f'model is: {model}')
         optimizer = getOptimizer(model, imageParams.optimizer_name, 0.05)
         criterionHandler = getCriterionHandler(imageParams.criterion)
         if imageParams.problem_type == "CLASSIFICATION":

--- a/training/training/routes/image/schemas.py
+++ b/training/training/routes/image/schemas.py
@@ -1,0 +1,22 @@
+from typing import Any, Literal, Optional
+from ninja import Schema
+
+
+class LayerParams(Schema):
+    value: str
+    parameters: list[Any]
+
+
+class ImageParams(Schema):
+    target: str
+    features: list[str]
+    name: str
+    problem_type: Literal["CLASSIFICATION"]
+    default: Optional[str]
+    criterion: str 
+    optimizer_name: str
+    shuffle: bool
+    epochs: int
+    test_size: float
+    batch_size: int
+    user_arch: list[LayerParams]

--- a/training/training/routes/image/schemas.py
+++ b/training/training/routes/image/schemas.py
@@ -8,8 +8,8 @@ class LayerParams(Schema):
 
 
 class ImageParams(Schema):
-    target: str
-    features: list[str]
+    # target: str
+    # features: list[str]
     name: str
     problem_type: Literal["CLASSIFICATION"]
     default: Optional[str]

--- a/training/training/routes/image/schemas.py
+++ b/training/training/routes/image/schemas.py
@@ -13,7 +13,7 @@ class ImageParams(Schema):
     name: str
     problem_type: Literal["CLASSIFICATION"]
     default: Optional[str]
-    criterion: str 
+    criterion: str
     optimizer_name: str
     shuffle: bool
     epochs: int

--- a/training/training/urls.py
+++ b/training/training/urls.py
@@ -19,9 +19,13 @@ from django.contrib import admin
 from django.http import HttpRequest
 from django.urls import path
 from ninja import NinjaAPI, Schema
-from training.routes.datasets.default import get_default_datasets_router
-from training.routes.tabular import get_tabular_router
-from training.routes.image import get_image_router
+
+from training.routes.datasets.default.columns import router as default_dataset_router
+from training.routes.tabular.tabular import router as tabular_router
+from training.routes.image.image import router as image_router
+# from training.routes.datasets.default import get_default_datasets_router
+# from training.routes.tabular import get_tabular_router
+# from training.routes.image import image_router
 
 api = NinjaAPI()
 
@@ -31,9 +35,9 @@ def test(request: HttpRequest):
     return 200, {"result": "200 Backend surface test successful"}
 
 
-api.add_router("/datasets/default/", get_default_datasets_router())
-api.add_router("/tabular", get_tabular_router())
-api.add_router("/image", get_image_router())
+api.add_router("/datasets/default/", default_dataset_router)
+api.add_router("/tabular", tabular_router)
+api.add_router("/image", image_router)
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/training/training/urls.py
+++ b/training/training/urls.py
@@ -23,9 +23,6 @@ from ninja import NinjaAPI, Schema
 from training.routes.datasets.default.columns import router as default_dataset_router
 from training.routes.tabular.tabular import router as tabular_router
 from training.routes.image.image import router as image_router
-# from training.routes.datasets.default import get_default_datasets_router
-# from training.routes.tabular import get_tabular_router
-# from training.routes.image import image_router
 
 api = NinjaAPI()
 

--- a/training/training/urls.py
+++ b/training/training/urls.py
@@ -21,6 +21,7 @@ from django.urls import path
 from ninja import NinjaAPI, Schema
 from training.routes.datasets.default import get_default_datasets_router
 from training.routes.tabular import get_tabular_router
+from training.routes.image import get_image_router
 
 api = NinjaAPI()
 
@@ -32,6 +33,7 @@ def test(request: HttpRequest):
 
 api.add_router("/datasets/default/", get_default_datasets_router())
 api.add_router("/tabular", get_tabular_router())
+api.add_router("/image", get_image_router())
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
# Migrate Image Training Endpoint to Django

Github Issue Number Here: Feature#993

**What user problem are we solving?**

With the ongoing migration from Flask Blueprint to Django for better scalability and maintainability, we need to ensure that the training endpoints for image datasets continue to function as expected. Users need a reliable endpoint to submit image training requests and this migration aims to improve the overall infrastructure.

**What solution does this PR provide?**


This PR introduces the /image route within the Django framework, replacing the old Flask Blueprint route. The new route handles image training requests, particularly focusing on classification tasks as regression is not supported. The structure of this endpoint is mirrored from the specified reference, with adjustments made to fit the Django framework. The old image train code served as inspiration for ensuring that the necessary features and behaviors are retained.


**Testing Methodology**

Testing yet to be done but to verify the functionality and integrity of the new /image route, but when testing begins, we can submit training requests using torch built-in datasets (MNIST, FashionMNIST) to ensure that models train as expected and the endpoint returns accurate results.

Also use postman for testing .

**Any other considerations**