### PR TITLE
AWS Setup Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ Run the following commands in the project directory (the root folder created aft
 
 Make sure to run the above two commands in separate terminals.
 
+## AWS Setup
+If you will be working on tasks that interface with AWS resources/services, please follow the below steps (please install AWS CLI using this [link](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) first):
+
+1. Request an AWS Account for Deep Learning Playground by messaging Faris, Karthik, or Daniel in the DLP Discord. Please include your Github username along with your personal email account
+1. Once an AWS Account has been created, you will receive an email from AWS that will require you to setup a password
+1. When you login, you should be seeing that the account you're added under is `Data Science Initiative Inc`
+1. Click on the dropdown to expand the `Data Science Initiative Inc` entry and select the `Command Line or programmatic access button`
+1. Open your terminal and navigate to the DLP directory
+   1. Run `aws configure sso``. Follow the prompts to enter the SSO Start URL (this comes from step 2) and the below values
+   ```
+   sso_region = us-east-1
+   sso_session = dlp
+   sso_registration_scopes = sso:account:access
+   default output format = None
+   cli profile name = just press enter (use the default one provided)
+   ````
+   1. Make sure you follow the instructions in the terminal to ensure your credentials are set correctly (eg: allow botocore to access data should be selected as "yes")
+   1. Run `cat ~/.aws/config` to look for the sso profile configured.
+   1. Run `export AWS_PROFILE=<sso_profile_name from step 6>`
+
+Please message in the DLP Discord if you have any difficulty/issue with these steps. 
+
 # Architecture
 
 See [Architecture.md](./.github/Architecture.md)


### PR DESCRIPTION
# AWS Setup Instructions

Github Issue Number Here: #1019 
**What user problem are we solving?**
Found a better way to setup AWS credentials through IAM identity + SSO. The instructions provided in the README.md provide a systematic way to setup AWS credentials for individual IAM Identity without the need to use a shared set of credentials
**What solution does this PR provide?**
clear instructions for how to setup IAM Identity + SSO for credentials
**Testing Methodology**
> How did you test your changes and verify that existing 
> functionality is not broken

Actually ran through the instructions on my account and worked seamlessly
**Any other considerations**