### PR TITLE
Unit Tests for /columns API Endpoint

### DIFF
--- a/.github/Architecture.md
+++ b/.github/Architecture.md
@@ -5,219 +5,219 @@
 ```
 📦 backend
 |  |- 📂 common:
-|  |  |- 📜 optimizer.py : what optimizer to use (ie: SGD or Adam for now)
-|  |  |- 📜 ai_drive.py
-|  |  |- 📜 preprocessing.py
 |  |  |- 📜 default_datasets.py : store logic to load in default datasets from scikit-learn
-|  |  |- 📜 dataset.py : read in the dataset through URL or file upload
-|  |  |- 📜 email_notifier.py : Endpoint to send email notification of training results via API Gateway + AWS SES
-|  |  |- 📜 utils.py : utility functions that could be helpful
-|  |  |- 📜 constants.py : list of helpful constants
+|  |  |- 📜 ai_drive.py
+|  |  |- 📜 optimizer.py : what optimizer to use (ie: SGD or Adam for now)
 |  |  |- 📜 __init__.py
 |  |  |- 📜 kernel.py
+|  |  |- 📜 constants.py : list of helpful constants
+|  |  |- 📜 dataset.py : read in the dataset through URL or file upload
+|  |  |- 📜 preprocessing.py
+|  |  |- 📜 utils.py : utility functions that could be helpful
+|  |  |- 📜 email_notifier.py : Endpoint to send email notification of training results via API Gateway + AWS SES
 |  |  |- 📜 loss_functions.py : loss function enum
+|  |- 📂 aws_helpers:
+|  |  |- 📂 dynamo_db_utils:
+|  |  |  |- 📜 userprogress_db.py
+|  |  |  |- 📜 constants.py : list of helpful constants
+|  |  |  |- 📜 DynamoUnitTests.md
+|  |  |  |- 📜 trainspace_db.py
+|  |  |  |- 📜 dynamo_db_utils.py
+|  |  |- 📜 __init__.py
 |  |- 📂 ml:
 |  |  |- 📜 ml_trainer.py : train a classical machine learning learning model on the dataset
-|  |  |- 📜 __init__.py
 |  |  |- 📜 ml_model_parser.py
+|  |  |- 📜 __init__.py
 |  |- 📂 dl:
+|  |  |- 📜 dl_model_parser.py : parse the user specified pytorch model
 |  |  |- 📜 dl_model.py : torch model based on user specifications from drag and drop
+|  |  |- 📜 __init__.py
 |  |  |- 📜 dl_eval.py : Evaluation functions for deep learning models in Pytorch (eg: accuracy, loss, etc)
 |  |  |- 📜 dl_trainer.py : train a deep learning model on the dataset
 |  |  |- 📜 detection.py
-|  |  |- 📜 __init__.py
-|  |  |- 📜 dl_model_parser.py : parse the user specified pytorch model
-|  |- 📂 aws_helpers:
-|  |  |- 📂 dynamo_db_utils:
-|  |  |  |- 📜 trainspace_db.py
-|  |  |  |- 📜 DynamoUnitTests.md
-|  |  |  |- 📜 constants.py : list of helpful constants
-|  |  |  |- 📜 dynamo_db_utils.py
-|  |  |  |- 📜 userprogress_db.py
-|  |  |- 📜 __init__.py
+|  |- 📜 __init__.py
+|  |- 📜 data.csv : data csv file for use in the playground
+|  |- 📜 pyproject.toml
 |  |- 📜 middleware.py
 |  |- 📜 poetry.lock
-|  |- 📜 epoch_times.csv
-|  |- 📜 pyproject.toml
-|  |- 📜 data.csv : data csv file for use in the playground
-|  |- 📜 __init__.py
 |  |- 📜 app.py : run the backend (entrypoint script)
+|  |- 📜 epoch_times.csv
 ```
 
 ## Frontend Architecture
 
 ```
 📦 frontend
+|  |- 📂 layer_docs:
+|  |  |- 📜 Softmax.md : Doc for Softmax layer
+|  |  |- 📜 Linear.md : Doc for Linear layer
+|  |  |- 📜 ReLU.md : Doc for ReLU later
+|  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
 |  |- 📂 public:
 |  |  |- 📂 images:
 |  |  |  |- 📂 wiki_images:
 |  |  |  |  |- 📜 tanh_plot.png
-|  |  |  |  |- 📜 avgpool_maxpool.gif
-|  |  |  |  |- 📜 conv2d2.gif
-|  |  |  |  |- 📜 conv2d.gif
-|  |  |  |  |- 📜 sigmoid_equation.png
-|  |  |  |  |- 📜 maxpool2d.gif
-|  |  |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
-|  |  |  |  |- 📜 batchnorm_diagram.png
 |  |  |  |  |- 📜 dropout_diagram.png
 |  |  |  |  |- 📜 tanh_equation.png
+|  |  |  |  |- 📜 conv2d2.gif
+|  |  |  |  |- 📜 batchnorm_diagram.png
+|  |  |  |  |- 📜 conv2d.gif
+|  |  |  |  |- 📜 maxpool2d.gif
+|  |  |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
+|  |  |  |  |- 📜 sigmoid_equation.png
+|  |  |  |  |- 📜 avgpool_maxpool.gif
 |  |  |  |- 📂 learn_mod_images:
-|  |  |  |  |- 📜 neuron.png
+|  |  |  |  |- 📜 lossExample.png
+|  |  |  |  |- 📜 robotImage.jpg
+|  |  |  |  |- 📜 LeakyReLUactivation.png
+|  |  |  |  |- 📜 neuralnet.png
+|  |  |  |  |- 📜 lossExampleTable.png
+|  |  |  |  |- 📜 binarystepactivation.png
+|  |  |  |  |- 📜 ReLUactivation.png
+|  |  |  |  |- 📜 sigmoidfunction.png
 |  |  |  |  |- 📜 tanhactivation.png
 |  |  |  |  |- 📜 neuronWithEquation.png
-|  |  |  |  |- 📜 sigmoidactivation.png
-|  |  |  |  |- 📜 lossExampleTable.png
-|  |  |  |  |- 📜 sigmoidfunction.png
+|  |  |  |  |- 📜 neuron.png
 |  |  |  |  |- 📜 lossExampleEquation.png
-|  |  |  |  |- 📜 neuralnet.png
-|  |  |  |  |- 📜 LeakyReLUactivation.png
-|  |  |  |  |- 📜 ReLUactivation.png
-|  |  |  |  |- 📜 robotImage.jpg
-|  |  |  |  |- 📜 binarystepactivation.png
-|  |  |  |  |- 📜 lossExample.png
+|  |  |  |  |- 📜 sigmoidactivation.png
 |  |  |  |- 📂 logos:
 |  |  |  |  |- 📂 dlp_branding:
-|  |  |  |  |  |- 📜 dlp-logo.svg : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
 |  |  |  |  |  |- 📜 dlp-logo.png : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
-|  |  |  |  |- 📜 react-logo.png
-|  |  |  |  |- 📜 google.png
-|  |  |  |  |- 📜 pytorch-logo.png
-|  |  |  |  |- 📜 pandas-logo.png
-|  |  |  |  |- 📜 dsgt-logo-dark.png
+|  |  |  |  |  |- 📜 dlp-logo.svg : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
 |  |  |  |  |- 📜 dsgt-logo-light.png
-|  |  |  |  |- 📜 python-logo.png
-|  |  |  |  |- 📜 dsgt-logo-white-back.png
+|  |  |  |  |- 📜 pandas-logo.png
 |  |  |  |  |- 📜 github.png
-|  |  |  |  |- 📜 aws-logo.png
 |  |  |  |  |- 📜 flask-logo.png
+|  |  |  |  |- 📜 react-logo.png
+|  |  |  |  |- 📜 aws-logo.png
+|  |  |  |  |- 📜 pytorch-logo.png
+|  |  |  |  |- 📜 dsgt-logo-white-back.png
+|  |  |  |  |- 📜 dsgt-logo-dark.png
+|  |  |  |  |- 📜 python-logo.png
+|  |  |  |  |- 📜 google.png
 |  |  |  |- 📜 demo_video.gif : GIF tutorial of a simple classification training session
-|  |  |- 📜 robots.txt
-|  |  |- 📜 dlp-logo.ico : DLP Logo
-|  |  |- 📜 index.html : Base HTML file that will be initially rendered
 |  |  |- 📜 manifest.json : Default React file for choosing icon based on
-|  |- 📂 layer_docs:
-|  |  |- 📜 Linear.md : Doc for Linear layer
-|  |  |- 📜 ReLU.md : Doc for ReLU later
-|  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
-|  |  |- 📜 Softmax.md : Doc for Softmax layer
+|  |  |- 📜 index.html : Base HTML file that will be initially rendered
+|  |  |- 📜 dlp-logo.ico : DLP Logo
+|  |  |- 📜 robots.txt
 |  |- 📂 src:
-|  |  |- 📂 pages:
-|  |  |  |- 📂 train:
-|  |  |  |  |- 📜 index.tsx
-|  |  |  |  |- 📜 [train_space_id].tsx
-|  |  |  |- 📜 _app.tsx
-|  |  |  |- 📜 _document.tsx
-|  |  |  |- 📜 LearnContent.tsx
-|  |  |  |- 📜 wiki.tsx
-|  |  |  |- 📜 learn.tsx
-|  |  |  |- 📜 forgot.tsx
-|  |  |  |- 📜 settings.tsx
-|  |  |  |- 📜 dashboard.tsx
-|  |  |  |- 📜 login.tsx
-|  |  |  |- 📜 about.tsx
-|  |  |  |- 📜 feedback.tsx
+|  |  |- 📂 backend_outputs:
+|  |  |  |- 📜 model.pt : Last model.pt output
+|  |  |  |- 📜 my_deep_learning_model.onnx : Last ONNX file output
+|  |  |  |- 📜 model.pkl
 |  |  |- 📂 common:
-|  |  |  |- 📂 styles:
-|  |  |  |  |- 📜 globals.css
-|  |  |  |  |- 📜 Home.module.css
 |  |  |  |- 📂 redux:
 |  |  |  |  |- 📜 userLogin.ts
+|  |  |  |  |- 📜 train.ts
 |  |  |  |  |- 📜 backendApi.ts
 |  |  |  |  |- 📜 store.ts
 |  |  |  |  |- 📜 hooks.ts
-|  |  |  |  |- 📜 train.ts
-|  |  |  |- 📂 utils:
-|  |  |  |  |- 📜 dndHelpers.ts
-|  |  |  |  |- 📜 firebase.ts
-|  |  |  |  |- 📜 dateFormat.ts
+|  |  |  |- 📂 styles:
+|  |  |  |  |- 📜 Home.module.css
+|  |  |  |  |- 📜 globals.css
 |  |  |  |- 📂 components:
 |  |  |  |  |- 📜 Spacer.tsx
 |  |  |  |  |- 📜 Footer.tsx
-|  |  |  |  |- 📜 HtmlTooltip.tsx
-|  |  |  |  |- 📜 DlpTooltip.tsx
-|  |  |  |  |- 📜 ClientOnlyPortal.tsx
-|  |  |  |  |- 📜 NavBarMain.tsx
-|  |  |  |  |- 📜 EmailInput.tsx
 |  |  |  |  |- 📜 TitleText.tsx
-|  |  |- 📂 backend_outputs:
-|  |  |  |- 📜 my_deep_learning_model.onnx : Last ONNX file output
-|  |  |  |- 📜 model.pt : Last model.pt output
-|  |  |  |- 📜 model.pkl
+|  |  |  |  |- 📜 DlpTooltip.tsx
+|  |  |  |  |- 📜 HtmlTooltip.tsx
+|  |  |  |  |- 📜 EmailInput.tsx
+|  |  |  |  |- 📜 NavBarMain.tsx
+|  |  |  |  |- 📜 ClientOnlyPortal.tsx
+|  |  |  |- 📂 utils:
+|  |  |  |  |- 📜 firebase.ts
+|  |  |  |  |- 📜 dndHelpers.ts
+|  |  |  |  |- 📜 dateFormat.ts
 |  |  |- 📂 features:
 |  |  |  |- 📂 Train:
+|  |  |  |  |- 📂 constants:
+|  |  |  |  |  |- 📜 trainConstants.ts
+|  |  |  |  |- 📂 types:
+|  |  |  |  |  |- 📜 trainTypes.ts
 |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |- 📜 trainspaceSlice.ts
 |  |  |  |  |  |- 📜 trainspaceApi.ts
 |  |  |  |  |- 📂 features:
 |  |  |  |  |  |- 📂 Image:
-|  |  |  |  |  |  |- 📂 redux:
-|  |  |  |  |  |  |  |- 📜 imageActions.ts
-|  |  |  |  |  |  |  |- 📜 imageApi.ts
-|  |  |  |  |  |  |- 📂 types:
-|  |  |  |  |  |  |  |- 📜 imageTypes.ts
 |  |  |  |  |  |  |- 📂 constants:
 |  |  |  |  |  |  |  |- 📜 imageConstants.ts
+|  |  |  |  |  |  |- 📂 types:
+|  |  |  |  |  |  |  |- 📜 imageTypes.ts
+|  |  |  |  |  |  |- 📂 redux:
+|  |  |  |  |  |  |  |- 📜 imageApi.ts
+|  |  |  |  |  |  |  |- 📜 imageActions.ts
 |  |  |  |  |  |  |- 📂 components:
-|  |  |  |  |  |  |  |- 📜 ImageParametersStep.tsx
-|  |  |  |  |  |  |  |- 📜 ImageTrainspace.tsx
 |  |  |  |  |  |  |  |- 📜 ImageFlow.tsx
 |  |  |  |  |  |  |  |- 📜 ImageDatasetStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageTrainspace.tsx
 |  |  |  |  |  |  |  |- 📜 ImageReviewStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageParametersStep.tsx
 |  |  |  |  |  |  |- 📜 index.ts
 |  |  |  |  |  |- 📂 Tabular:
+|  |  |  |  |  |  |- 📂 constants:
+|  |  |  |  |  |  |  |- 📜 tabularConstants.ts
+|  |  |  |  |  |  |- 📂 types:
+|  |  |  |  |  |  |  |- 📜 tabularTypes.ts
 |  |  |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |  |  |- 📜 tabularActions.ts
 |  |  |  |  |  |  |  |- 📜 tabularApi.ts
-|  |  |  |  |  |  |- 📂 types:
-|  |  |  |  |  |  |  |- 📜 tabularTypes.ts
-|  |  |  |  |  |  |- 📂 constants:
-|  |  |  |  |  |  |  |- 📜 tabularConstants.ts
 |  |  |  |  |  |  |- 📂 components:
 |  |  |  |  |  |  |  |- 📜 TabularParametersStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularTrainspace.tsx
 |  |  |  |  |  |  |  |- 📜 TabularDatasetStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularReviewStep.tsx
+|  |  |  |  |  |  |  |- 📜 TabularTrainspace.tsx
 |  |  |  |  |  |  |  |- 📜 TabularFlow.tsx
+|  |  |  |  |  |  |  |- 📜 TabularReviewStep.tsx
 |  |  |  |  |  |  |- 📜 index.ts
-|  |  |  |  |- 📂 types:
-|  |  |  |  |  |- 📜 trainTypes.ts
-|  |  |  |  |- 📂 constants:
-|  |  |  |  |  |- 📜 trainConstants.ts
 |  |  |  |  |- 📂 components:
 |  |  |  |  |  |- 📜 CreateTrainspace.tsx
-|  |  |  |  |  |- 📜 TrainspaceLayout.tsx
 |  |  |  |  |  |- 📜 DatasetStepLayout.tsx
-|  |  |  |- 📂 OpenAi:
-|  |  |  |  |- 📜 openAiUtils.ts
+|  |  |  |  |  |- 📜 TrainspaceLayout.tsx
+|  |  |  |- 📂 Feedback:
+|  |  |  |  |- 📂 redux:
+|  |  |  |  |  |- 📜 feedbackApi.ts
 |  |  |  |- 📂 Dashboard:
 |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |- 📜 dashboardApi.ts
 |  |  |  |  |- 📂 components:
-|  |  |  |  |  |- 📜 TrainBarChart.tsx
 |  |  |  |  |  |- 📜 TrainDataGrid.tsx
+|  |  |  |  |  |- 📜 TrainBarChart.tsx
 |  |  |  |  |  |- 📜 TrainDoughnutChart.tsx
-|  |  |  |- 📂 Feedback:
-|  |  |  |  |- 📂 redux:
-|  |  |  |  |  |- 📜 feedbackApi.ts
 |  |  |  |- 📂 LearnMod:
+|  |  |  |  |- 📜 MCQuestion.tsx
+|  |  |  |  |- 📜 ImageComponent.tsx
+|  |  |  |  |- 📜 ModulesSideBar.tsx
+|  |  |  |  |- 📜 Exercise.tsx
 |  |  |  |  |- 📜 FRQuestion.tsx
 |  |  |  |  |- 📜 LearningModulesContent.tsx
-|  |  |  |  |- 📜 ModulesSideBar.tsx
-|  |  |  |  |- 📜 MCQuestion.tsx
 |  |  |  |  |- 📜 ClassCard.tsx
-|  |  |  |  |- 📜 ImageComponent.tsx
-|  |  |  |  |- 📜 Exercise.tsx
-|  |  |- 📜 next-env.d.ts
+|  |  |  |- 📂 OpenAi:
+|  |  |  |  |- 📜 openAiUtils.ts
+|  |  |- 📂 pages:
+|  |  |  |- 📂 train:
+|  |  |  |  |- 📜 index.tsx
+|  |  |  |  |- 📜 [train_space_id].tsx
+|  |  |  |- 📜 login.tsx
+|  |  |  |- 📜 feedback.tsx
+|  |  |  |- 📜 learn.tsx
+|  |  |  |- 📜 dashboard.tsx
+|  |  |  |- 📜 about.tsx
+|  |  |  |- 📜 _document.tsx
+|  |  |  |- 📜 _app.tsx
+|  |  |  |- 📜 settings.tsx
+|  |  |  |- 📜 forgot.tsx
+|  |  |  |- 📜 LearnContent.tsx
+|  |  |  |- 📜 wiki.tsx
 |  |  |- 📜 iris.csv : Sample CSV data
 |  |  |- 📜 GlobalStyle.ts
 |  |  |- 📜 constants.ts
-|  |- 📜 next-env.d.ts
-|  |- 📜 tsconfig.json
+|  |  |- 📜 next-env.d.ts
 |  |- 📜 next.config.js
 |  |- 📜 jest.config.js
 |  |- 📜 .eslintrc.json
-|  |- 📜 pnpm-lock.yaml
 |  |- 📜 package.json
+|  |- 📜 tsconfig.json
+|  |- 📜 pnpm-lock.yaml
+|  |- 📜 next-env.d.ts
 |  |- 📜 .eslintignore
 ```
 

--- a/training/tests/test_dataset_endpoint.py
+++ b/training/tests/test_dataset_endpoint.py
@@ -3,38 +3,29 @@ from tests.utils.test_utils import mock_authenticate, get_test_bearer_token
 from django.test import Client
 from training.core.authenticator import FirebaseAuth
 
+
 @pytest.mark.parametrize(
-    "dataset_name", [
-        "IRIS",
-        "CALIFORNIA_HOUSING",
-        "DIABETES",
-        "WINE"
-    ]
+    "dataset_name", ["IRIS", "CALIFORNIA_HOUSING", "DIABETES", "WINE"]
 )
 def test_columns_endpoint(monkeypatch, dataset_name):
     client = Client()
     # Use monkeypatch to replace FirebaseAuth.authenticate with our mock function
     monkeypatch.setattr(FirebaseAuth, "authenticate", mock_authenticate)
-    
+
     # Set the Authorization header with the fake token
     headers = get_test_bearer_token()
-    response = client.get(f'/api/datasets/default/{dataset_name}/columns', **headers)
+    response = client.get(f"/api/datasets/default/{dataset_name}/columns", **headers)
     assert response.status_code == 200
     assert isinstance(response.json(), dict)
 
-@pytest.mark.parametrize(
-    "dataset_name", [
-        "TEST_DATASET",
-        "HELLO",
-        None
-    ]
-)
+
+@pytest.mark.parametrize("dataset_name", ["TEST_DATASET", "HELLO", None])
 def test_columns_invalid_default(monkeypatch, dataset_name):
     client = Client()
     # Use monkeypatch to replace FirebaseAuth.authenticate with our mock function
     monkeypatch.setattr(FirebaseAuth, "authenticate", mock_authenticate)
-    headers = get_test_bearer_token() 
-    response = client.get(f'/api/datasets/default/{dataset_name}/columns', **headers)
-    print(f'Response: {vars(response)}')
+    headers = get_test_bearer_token()
+    response = client.get(f"/api/datasets/default/{dataset_name}/columns", **headers)
+    print(f"Response: {vars(response)}")
     assert response.status_code == 404
-    assert response.content.decode('utf-8') == '{"message": "Dataset not found"}'
+    assert response.content.decode("utf-8") == '{"message": "Dataset not found"}'

--- a/training/tests/test_dataset_endpoint.py
+++ b/training/tests/test_dataset_endpoint.py
@@ -1,0 +1,40 @@
+import pytest
+from tests.utils.test_utils import mock_authenticate, get_test_bearer_token
+from django.test import Client
+from training.core.authenticator import FirebaseAuth
+
+@pytest.mark.parametrize(
+    "dataset_name", [
+        "IRIS",
+        "CALIFORNIA_HOUSING",
+        "DIABETES",
+        "WINE"
+    ]
+)
+def test_columns_endpoint(monkeypatch, dataset_name):
+    client = Client()
+    # Use monkeypatch to replace FirebaseAuth.authenticate with our mock function
+    monkeypatch.setattr(FirebaseAuth, "authenticate", mock_authenticate)
+    
+    # Set the Authorization header with the fake token
+    headers = get_test_bearer_token()
+    response = client.get(f'/api/datasets/default/{dataset_name}/columns', **headers)
+    assert response.status_code == 200
+    assert isinstance(response.json(), dict)
+
+@pytest.mark.parametrize(
+    "dataset_name", [
+        "TEST_DATASET",
+        "HELLO",
+        None
+    ]
+)
+def test_columns_invalid_default(monkeypatch, dataset_name):
+    client = Client()
+    # Use monkeypatch to replace FirebaseAuth.authenticate with our mock function
+    monkeypatch.setattr(FirebaseAuth, "authenticate", mock_authenticate)
+    headers = get_test_bearer_token() 
+    response = client.get(f'/api/datasets/default/{dataset_name}/columns', **headers)
+    print(f'Response: {vars(response)}')
+    assert response.status_code == 404
+    assert response.content.decode('utf-8') == '{"message": "Dataset not found"}'

--- a/training/tests/test_dataset_endpoint.py
+++ b/training/tests/test_dataset_endpoint.py
@@ -11,7 +11,6 @@ def test_columns_endpoint(monkeypatch, dataset_name):
     client = Client()
     # Use monkeypatch to replace FirebaseAuth.authenticate with our mock function
     monkeypatch.setattr(FirebaseAuth, "authenticate", mock_authenticate)
-
     # Set the Authorization header with the fake token
     headers = get_test_bearer_token()
     response = client.get(f"/api/datasets/default/{dataset_name}/columns", **headers)
@@ -26,6 +25,5 @@ def test_columns_invalid_default(monkeypatch, dataset_name):
     monkeypatch.setattr(FirebaseAuth, "authenticate", mock_authenticate)
     headers = get_test_bearer_token()
     response = client.get(f"/api/datasets/default/{dataset_name}/columns", **headers)
-    print(f"Response: {vars(response)}")
     assert response.status_code == 404
     assert response.content.decode("utf-8") == '{"message": "Dataset not found"}'

--- a/training/tests/utils/test_utils.py
+++ b/training/tests/utils/test_utils.py
@@ -1,0 +1,30 @@
+"""
+File that houses helper functions for testing the training backend 
+"""
+import jwt
+import datetime
+
+def mock_authenticate(*args, **kwargs) -> str:
+    """
+    Function that gives a test JWT Token for testing (not necessarily real user data)
+    Django API Endpoints that require user authentication
+
+    Returns:
+        token: Bearer Token
+    """
+    payload = {
+        "sub": "1234567890",
+        "name": "John Doe",
+        "iat": datetime.datetime.utcnow(),
+        "exp": datetime.datetime.utcnow() + datetime.timedelta(days=1),
+    }
+    secret = 'secret' 
+    token = jwt.encode(payload, secret, algorithm='HS256')
+    return token
+
+def get_test_bearer_token() -> dict:
+    """
+    Wrapper that uses mock_authenticate function to build a bearer token 
+    in a format that Django accepts
+    """
+    return {'HTTP_AUTHORIZATION': 'Bearer ' + mock_authenticate()}

--- a/training/tests/utils/test_utils.py
+++ b/training/tests/utils/test_utils.py
@@ -4,6 +4,7 @@ File that houses helper functions for testing the training backend
 import jwt
 import datetime
 
+
 def mock_authenticate(*args, **kwargs) -> str:
     """
     Function that gives a test JWT Token for testing (not necessarily real user data)
@@ -18,13 +19,14 @@ def mock_authenticate(*args, **kwargs) -> str:
         "iat": datetime.datetime.utcnow(),
         "exp": datetime.datetime.utcnow() + datetime.timedelta(days=1),
     }
-    secret = 'secret' 
-    token = jwt.encode(payload, secret, algorithm='HS256')
+    secret = "secret"
+    token = jwt.encode(payload, secret, algorithm="HS256")
     return token
+
 
 def get_test_bearer_token() -> dict:
     """
-    Wrapper that uses mock_authenticate function to build a bearer token 
+    Wrapper that uses mock_authenticate function to build a bearer token
     in a format that Django accepts
     """
-    return {'HTTP_AUTHORIZATION': 'Bearer ' + mock_authenticate()}
+    return {"HTTP_AUTHORIZATION": "Bearer " + mock_authenticate()}


### PR DESCRIPTION
# Unit tests for `/columns` Dataset API Endpoint

Github Issue Number Here: #1059
**What user problem are we solving?**
Currently, we have unit tests in `pytest` for the core training files. However, to increase test coverage on our backend, we should add unit tests for the Django training endpoints we have in the codebase. 

**What solution does this PR provide?**
Unit tests for the `/columns` API Route under `/api/datasets/default/columns` endpoint. 

**Testing Methodology**
Checkout this branch on your local machine and then run `cd training && pytest tests/` at the root of the project

**Any other considerations**
For any utility files that are created for the purpose of being reused across unit tests within `training/` please add it under `test_utils.py` (see example functions I've added)