### PR TITLE
Change region to 'us-east-1' and set custom exception for incomplete AWS credential steps

### DIFF
--- a/training/cli.py
+++ b/training/cli.py
@@ -6,13 +6,6 @@ from botocore.exceptions import ClientError
 import click
 import requests
 
-class AuthentificationError(Exception):
-    def __init__(self, message=None, errors=None):
-        if errors and 'UnrecognizedClientException' in str(errors):
-            message = "AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`"
-        super().__init__(message)
-        self.errors = errors
-
 def init_firebase():
     secret_name = "DLP/Firebase/Admin_SDK"
     region_name = "us-east-1"
@@ -22,9 +15,11 @@ def init_firebase():
     try:
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)
     except ClientError as e:
+        if 'UnrecognizedClientException' in str(e.response['Error']['Code']):
+            raise Exception("AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`")
         # For a list of exceptions thrown, see
         # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-        raise AuthentificationError(errors=e)
+        raise e
 
     # Decrypts secret using the associated KMS key.
     secret_str = get_secret_value_response["SecretString"]

--- a/training/cli.py
+++ b/training/cli.py
@@ -18,8 +18,10 @@ def init_firebase():
     # For a list of exceptions thrown, see
     # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
     except ClientError as e:
-        if 'UnrecognizedClientException' in str(e.response['Error']['Code']):
-            raise RuntimeError("AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`")
+        if "UnrecognizedClientException" in str(e.response["Error"]["Code"]):
+            raise RuntimeError(
+                "AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`"
+            )
         raise e
 
     # Decrypts secret using the associated KMS key.

--- a/training/cli.py
+++ b/training/cli.py
@@ -6,6 +6,7 @@ from botocore.exceptions import ClientError
 import click
 import requests
 
+
 def init_firebase():
     secret_name = "DLP/Firebase/Admin_SDK"
     region_name = "us-east-1"
@@ -17,8 +18,10 @@ def init_firebase():
     # For a list of exceptions thrown, see
     # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
     except ClientError as e:
-        if 'UnrecognizedClientException' in str(e.response['Error']['Code']):
-            raise Exception("AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`")
+        if "UnrecognizedClientException" in str(e.response["Error"]["Code"]):
+            raise Exception(
+                "AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`"
+            )
         raise e
 
     # Decrypts secret using the associated KMS key.

--- a/training/cli.py
+++ b/training/cli.py
@@ -18,7 +18,7 @@ def init_firebase():
     # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
     except ClientError as e:
         if 'UnrecognizedClientException' in str(e.response['Error']['Code']):
-            raise Exception("AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`")
+            raise RuntimeError("AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`")
         raise e
 
     # Decrypts secret using the associated KMS key.

--- a/training/cli.py
+++ b/training/cli.py
@@ -6,20 +6,25 @@ from botocore.exceptions import ClientError
 import click
 import requests
 
+class AuthentificationError(Exception):
+    def __init__(self, message=None, errors=None):
+        if errors and 'UnrecognizedClientException' in str(errors):
+            message = "AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`"
+        super().__init__(message)
+        self.errors = errors
 
 def init_firebase():
     secret_name = "DLP/Firebase/Admin_SDK"
-    region_name = "us-west-2"
+    region_name = "us-east-1"
     # Create a Secrets Manager client
 
     client = boto3.client("secretsmanager", region_name=region_name)
-
     try:
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)
     except ClientError as e:
         # For a list of exceptions thrown, see
         # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-        raise e
+        raise AuthentificationError(errors=e)
 
     # Decrypts secret using the associated KMS key.
     secret_str = get_secret_value_response["SecretString"]

--- a/training/cli.py
+++ b/training/cli.py
@@ -6,12 +6,14 @@ from botocore.exceptions import ClientError
 import click
 import requests
 
+
 class AuthentificationError(Exception):
     def __init__(self, message=None, errors=None):
-        if errors and 'UnrecognizedClientException' in str(errors):
+        if errors and "UnrecognizedClientException" in str(errors):
             message = "AWS authentification incomplete. Make sure all credentials are set correctly including `export AWS_PROFILE=<profile-name>`"
         super().__init__(message)
         self.errors = errors
+
 
 def init_firebase():
     secret_name = "DLP/Firebase/Admin_SDK"


### PR DESCRIPTION
Change region to 'us-east-1' and set custom exception for incomplete AWS credential steps

Github Issue Number Here: #1084 
**Issue Description**
Bug preventing access to user id tokens through the dlp-cli with unclear error message

**Solution**
Edited cli.py file to use the correct region (us-east-1) and added custom exception providing a more detailed error description in the case where dlp-cli user did not complete the necessary AWS credential steps.

**Testing Methodology**
Tested the updates by using the dlp-cli to obtain a valid id token. First by not completing the proper AWS credential steps to prompt the custom exception and second by filling out the necessary steps and successfully getting the token. 

https://drive.google.com/file/d/1jThsq6Xznm4oAS_NN-o_Yt-7nBc_K5v_/view?usp=sharin
