### PR TITLE
Deploy training backend to ecs

### DIFF
--- a/.aws/training-task-definition.json
+++ b/.aws/training-task-definition.json
@@ -1,120 +1,80 @@
 {
-  "ipcMode": null,
-  "executionRoleArn": "arn:aws:iam::521654603461:role/ecsTaskExecutionRole",
+  "taskDefinitionArn": "arn:aws:ecs:us-east-1:521654603461:task-definition/DeployBackendTask:7",
   "containerDefinitions": [
-    {
-      "dnsSearchDomains": null,
-      "environmentFiles": null,
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "secretOptions": null,
-        "options": {
-          "awslogs-group": "/ecs/dlp-training-task",
-          "awslogs-region": "us-west-2",
-          "awslogs-stream-prefix": "ecs"
-        }
+      {
+          "name": "backend",
+          "image": "521654603461.dkr.ecr.us-east-1.amazonaws.com/dlp-backend-image",
+          "cpu": 0,
+          "portMappings": [
+              {
+                  "name": "gunicorn-port",
+                  "containerPort": 8000,
+                  "hostPort": 0,
+                  "protocol": "tcp",
+                  "appProtocol": "http"
+              }
+          ],
+          "essential": true,
+          "environment": [],
+          "environmentFiles": [],
+          "mountPoints": [],
+          "volumesFrom": [],
+          "ulimits": [],
+          "logConfiguration": {
+              "logDriver": "awslogs",
+              "options": {
+                  "awslogs-create-group": "true",
+                  "awslogs-group": "/ecs/DeployBackendTask",
+                  "awslogs-region": "us-east-1",
+                  "awslogs-stream-prefix": "ecs"
+              },
+              "secretOptions": []
+          }
+      }
+  ],
+  "family": "DeployBackendTask",
+  "executionRoleArn": "arn:aws:iam::521654603461:role/ecsTaskExecutionRole",
+  "networkMode": "bridge",
+  "revision": 7,
+  "volumes": [],
+  "status": "ACTIVE",
+  "requiresAttributes": [
+      {
+          "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
       },
-      "entryPoint": [],
-      "portMappings": [],
-      "command": [],
-      "linuxParameters": null,
-      "cpu": 0,
-      "environment": [],
-      "resourceRequirements": null,
-      "ulimits": null,
-      "dnsServers": null,
-      "mountPoints": [],
-      "workingDirectory": null,
-      "secrets": null,
-      "dockerSecurityOptions": null,
-      "memory": null,
-      "memoryReservation": null,
-      "volumesFrom": [],
-      "stopTimeout": null,
-      "image": "521654603461.dkr.ecr.us-west-2.amazonaws.com/dlp-training:latest",
-      "startTimeout": null,
-      "firelensConfiguration": null,
-      "dependsOn": null,
-      "disableNetworking": null,
-      "interactive": null,
-      "healthCheck": null,
-      "essential": true,
-      "links": null,
-      "hostname": null,
-      "extraHosts": null,
-      "pseudoTerminal": null,
-      "user": null,
-      "readonlyRootFilesystem": null,
-      "dockerLabels": null,
-      "systemControls": null,
-      "privileged": null,
-      "name": "dlp-training-container"
-    }
+      {
+          "name": "ecs.capability.execution-role-awslogs"
+      },
+      {
+          "name": "com.amazonaws.ecs.capability.ecr-auth"
+      },
+      {
+          "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+      },
+      {
+          "name": "ecs.capability.execution-role-ecr-pull"
+      },
+      {
+          "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+      },
+      {
+          "name": "com.amazonaws.ecs.capability.docker-remote-api.1.29"
+      }
   ],
   "placementConstraints": [],
-  "memory": "5120",
-  "taskRoleArn": "arn:aws:iam::521654603461:role/ecsTaskExecutionRole",
-  "compatibilities": ["EC2", "FARGATE"],
-  "taskDefinitionArn": "arn:aws:ecs:us-west-2:521654603461:task-definition/dlp-training-task:1",
-  "family": "dlp-training-task",
-  "requiresAttributes": [
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "ecs.capability.execution-role-awslogs"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.ecr-auth"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.task-iam-role"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "ecs.capability.execution-role-ecr-pull"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "ecs.capability.task-eni"
-    }
+  "compatibilities": [
+      "EC2"
   ],
-  "pidMode": null,
-  "requiresCompatibilities": ["FARGATE"],
-  "networkMode": "awsvpc",
-  "runtimePlatform": null,
-  "cpu": "2048",
-  "revision": 1,
-  "status": "ACTIVE",
-  "inferenceAccelerators": null,
-  "proxyConfiguration": null,
-  "volumes": []
+  "requiresCompatibilities": [
+      "EC2"
+  ],
+  "cpu": "1024",
+  "memory": "4096",
+  "runtimePlatform": {
+      "cpuArchitecture": "X86_64",
+      "operatingSystemFamily": "LINUX"
+  },
+  "registeredAt": "2024-01-27T20:50:42.266Z",
+  "registeredBy": "arn:aws:sts::521654603461:assumed-role/AWSReservedSSO_DLP_Deploy_a2424e895155366c/AndrewPeng",
+  "tags": []
 }

--- a/.aws/training-task-definition.json
+++ b/.aws/training-task-definition.json
@@ -1,80 +1,80 @@
 {
-  "taskDefinitionArn": "arn:aws:ecs:us-east-1:521654603461:task-definition/DeployBackendTask:7",
+  "taskDefinitionArn": "arn:aws:ecs:us-east-1:521654603461:task-definition/DeployBackendTask:8",
   "containerDefinitions": [
-      {
-          "name": "backend",
-          "image": "521654603461.dkr.ecr.us-east-1.amazonaws.com/dlp-backend-image",
-          "cpu": 0,
-          "portMappings": [
-              {
-                  "name": "gunicorn-port",
-                  "containerPort": 8000,
-                  "hostPort": 0,
-                  "protocol": "tcp",
-                  "appProtocol": "http"
-              }
-          ],
-          "essential": true,
-          "environment": [],
-          "environmentFiles": [],
-          "mountPoints": [],
-          "volumesFrom": [],
-          "ulimits": [],
-          "logConfiguration": {
-              "logDriver": "awslogs",
-              "options": {
-                  "awslogs-create-group": "true",
-                  "awslogs-group": "/ecs/DeployBackendTask",
-                  "awslogs-region": "us-east-1",
-                  "awslogs-stream-prefix": "ecs"
-              },
-              "secretOptions": []
-          }
+    {
+      "name": "backend",
+      "image": "521654603461.dkr.ecr.us-east-1.amazonaws.com/dlp-backend-image",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "name": "gunicorn-port",
+          "containerPort": 8000,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": true,
+      "environment": [],
+      "environmentFiles": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "true",
+          "awslogs-group": "/ecs/DeployBackendTask",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "ecs"
+        },
+        "secretOptions": []
       }
+    }
   ],
   "family": "DeployBackendTask",
+  "taskRoleArn": "arn:aws:iam::521654603461:role/DLPEcsTaskRole",
   "executionRoleArn": "arn:aws:iam::521654603461:role/ecsTaskExecutionRole",
   "networkMode": "bridge",
-  "revision": 7,
+  "revision": 8,
   "volumes": [],
   "status": "ACTIVE",
   "requiresAttributes": [
-      {
-          "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
-      },
-      {
-          "name": "ecs.capability.execution-role-awslogs"
-      },
-      {
-          "name": "com.amazonaws.ecs.capability.ecr-auth"
-      },
-      {
-          "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
-      },
-      {
-          "name": "ecs.capability.execution-role-ecr-pull"
-      },
-      {
-          "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
-      },
-      {
-          "name": "com.amazonaws.ecs.capability.docker-remote-api.1.29"
-      }
+    {
+      "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+    },
+    {
+      "name": "ecs.capability.execution-role-awslogs"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.ecr-auth"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.task-iam-role"
+    },
+    {
+      "name": "ecs.capability.execution-role-ecr-pull"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.29"
+    }
   ],
   "placementConstraints": [],
-  "compatibilities": [
-      "EC2"
-  ],
-  "requiresCompatibilities": [
-      "EC2"
-  ],
+  "compatibilities": ["EC2"],
+  "requiresCompatibilities": ["EC2"],
   "cpu": "1024",
   "memory": "4096",
   "runtimePlatform": {
-      "cpuArchitecture": "X86_64",
-      "operatingSystemFamily": "LINUX"
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
   },
-  "registeredAt": "2024-01-27T20:50:42.266Z",
+  "registeredAt": "2024-01-27T21:47:05.605Z",
   "registeredBy": "arn:aws:sts::521654603461:assumed-role/AWSReservedSSO_DLP_Deploy_a2424e895155366c/AndrewPeng",
   "tags": []
 }

--- a/.github/Architecture.md
+++ b/.github/Architecture.md
@@ -6,16 +6,16 @@
 📦 training
 |  |- 📂 training:
 |  |  |- 📂 routes:
+|  |  |  |- 📂 tabular:
+|  |  |  |  |- 📜 __init__.py
+|  |  |  |  |- 📜 schemas.py
+|  |  |  |  |- 📜 tabular.py
 |  |  |  |- 📂 datasets:
 |  |  |  |  |- 📂 default:
 |  |  |  |  |  |- 📜 columns.py
 |  |  |  |  |  |- 📜 __init__.py
 |  |  |  |  |  |- 📜 schemas.py
 |  |  |  |  |- 📜 __init__.py
-|  |  |  |- 📂 tabular:
-|  |  |  |  |- 📜 __init__.py
-|  |  |  |  |- 📜 tabular.py
-|  |  |  |  |- 📜 schemas.py
 |  |  |  |- 📂 image:
 |  |  |  |  |- 📜 image.py
 |  |  |  |  |- 📜 __init__.py
@@ -23,28 +23,29 @@
 |  |  |  |- 📜 __init__.py
 |  |  |  |- 📜 schemas.py
 |  |  |- 📂 core:
-|  |  |  |- 📜 dataset.py : read in the dataset through URL or file upload
-|  |  |  |- 📜 __init__.py
-|  |  |  |- 📜 authenticator.py
-|  |  |  |- 📜 optimizer.py : what optimizer to use (ie: SGD or Adam for now)
-|  |  |  |- 📜 trainer.py
 |  |  |  |- 📜 dl_model.py : torch model based on user specifications from drag and drop
+|  |  |  |- 📜 trainer.py
+|  |  |  |- 📜 authenticator.py
+|  |  |  |- 📜 __init__.py
+|  |  |  |- 📜 dataset.py : read in the dataset through URL or file upload
 |  |  |  |- 📜 criterion.py
+|  |  |  |- 📜 optimizer.py : what optimizer to use (ie: SGD or Adam for now)
 |  |  |- 📜 settings.py
-|  |  |- 📜 asgi.py
-|  |  |- 📜 wsgi.py
-|  |  |- 📜 __init__.py
 |  |  |- 📜 urls.py
-|  |- 📜 environment.yml
+|  |  |- 📜 wsgi.py
+|  |  |- 📜 asgi.py
+|  |  |- 📜 __init__.py
 |  |- 📜 poetry.lock
-|  |- 📜 manage.py
-|  |- 📜 docker-compose.yml
-|  |- 📜 cli.py
-|  |- 📜 docker-compose.prod.yml
-|  |- 📜 pytest.ini
 |  |- 📜 pyproject.toml
+|  |- 📜 docker-compose.prod.yml
+|  |- 📜 docker-compose.yml
+|  |- 📜 Dockerfile.prod
+|  |- 📜 pytest.ini
+|  |- 📜 manage.py
+|  |- 📜 environment.yml
 |  |- 📜 README.md
 |  |- 📜 Dockerfile
+|  |- 📜 cli.py
 ```
 
 ## Frontend Architecture
@@ -52,176 +53,176 @@
 ```
 📦 frontend
 |  |- 📂 layer_docs:
-|  |  |- 📜 ReLU.md : Doc for ReLU later
 |  |  |- 📜 Linear.md : Doc for Linear layer
-|  |  |- 📜 Softmax.md : Doc for Softmax layer
 |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
+|  |  |- 📜 Softmax.md : Doc for Softmax layer
+|  |  |- 📜 ReLU.md : Doc for ReLU later
 |  |- 📂 public:
 |  |  |- 📂 images:
+|  |  |  |- 📂 learn_mod_images:
+|  |  |  |  |- 📜 binarystepactivation.png
+|  |  |  |  |- 📜 lossExampleEquation.png
+|  |  |  |  |- 📜 robotImage.jpg
+|  |  |  |  |- 📜 sigmoidfunction.png
+|  |  |  |  |- 📜 tanhactivation.png
+|  |  |  |  |- 📜 lossExampleTable.png
+|  |  |  |  |- 📜 neuron.png
+|  |  |  |  |- 📜 sigmoidactivation.png
+|  |  |  |  |- 📜 ReLUactivation.png
+|  |  |  |  |- 📜 lossExample.png
+|  |  |  |  |- 📜 neuralnet.png
+|  |  |  |  |- 📜 neuronWithEquation.png
+|  |  |  |  |- 📜 LeakyReLUactivation.png
+|  |  |  |- 📂 wiki_images:
+|  |  |  |  |- 📜 tanh_equation.png
+|  |  |  |  |- 📜 avgpool_maxpool.gif
+|  |  |  |  |- 📜 batchnorm_diagram.png
+|  |  |  |  |- 📜 conv2d.gif
+|  |  |  |  |- 📜 tanh_plot.png
+|  |  |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
+|  |  |  |  |- 📜 dropout_diagram.png
+|  |  |  |  |- 📜 sigmoid_equation.png
+|  |  |  |  |- 📜 conv2d2.gif
+|  |  |  |  |- 📜 maxpool2d.gif
 |  |  |  |- 📂 logos:
 |  |  |  |  |- 📂 dlp_branding:
 |  |  |  |  |  |- 📜 dlp-logo.png : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
 |  |  |  |  |  |- 📜 dlp-logo.svg : DLP Logo, duplicate of files in public, but essential as the frontend can't read public
 |  |  |  |  |- 📜 flask-logo.png
+|  |  |  |  |- 📜 dsgt-logo-white-back.png
+|  |  |  |  |- 📜 aws-logo.png
+|  |  |  |  |- 📜 pandas-logo.png
+|  |  |  |  |- 📜 react-logo.png
+|  |  |  |  |- 📜 github.png
+|  |  |  |  |- 📜 google.png
 |  |  |  |  |- 📜 dsgt-logo-dark.png
 |  |  |  |  |- 📜 dsgt-logo-light.png
 |  |  |  |  |- 📜 python-logo.png
-|  |  |  |  |- 📜 github.png
-|  |  |  |  |- 📜 google.png
-|  |  |  |  |- 📜 aws-logo.png
-|  |  |  |  |- 📜 react-logo.png
-|  |  |  |  |- 📜 pandas-logo.png
 |  |  |  |  |- 📜 pytorch-logo.png
-|  |  |  |  |- 📜 dsgt-logo-white-back.png
-|  |  |  |- 📂 wiki_images:
-|  |  |  |  |- 📜 avgpool_maxpool.gif
-|  |  |  |  |- 📜 dropout_diagram.png
-|  |  |  |  |- 📜 tanh_equation.png
-|  |  |  |  |- 📜 maxpool2d.gif
-|  |  |  |  |- 📜 conv2d2.gif
-|  |  |  |  |- 📜 sigmoid_equation.png
-|  |  |  |  |- 📜 softmax_equation.png : PNG file of Softmax equation
-|  |  |  |  |- 📜 conv2d.gif
-|  |  |  |  |- 📜 batchnorm_diagram.png
-|  |  |  |  |- 📜 tanh_plot.png
-|  |  |  |- 📂 learn_mod_images:
-|  |  |  |  |- 📜 sigmoidactivation.png
-|  |  |  |  |- 📜 sigmoidfunction.png
-|  |  |  |  |- 📜 lossExampleTable.png
-|  |  |  |  |- 📜 lossExample.png
-|  |  |  |  |- 📜 LeakyReLUactivation.png
-|  |  |  |  |- 📜 robotImage.jpg
-|  |  |  |  |- 📜 tanhactivation.png
-|  |  |  |  |- 📜 ReLUactivation.png
-|  |  |  |  |- 📜 neuron.png
-|  |  |  |  |- 📜 binarystepactivation.png
-|  |  |  |  |- 📜 lossExampleEquation.png
-|  |  |  |  |- 📜 neuronWithEquation.png
-|  |  |  |  |- 📜 neuralnet.png
 |  |  |  |- 📜 demo_video.gif : GIF tutorial of a simple classification training session
-|  |  |- 📜 manifest.json : Default React file for choosing icon based on
-|  |  |- 📜 robots.txt
-|  |  |- 📜 index.html : Base HTML file that will be initially rendered
 |  |  |- 📜 dlp-logo.ico : DLP Logo
+|  |  |- 📜 index.html : Base HTML file that will be initially rendered
+|  |  |- 📜 robots.txt
+|  |  |- 📜 manifest.json : Default React file for choosing icon based on
 |  |- 📂 src:
 |  |  |- 📂 features:
-|  |  |  |- 📂 LearnMod:
-|  |  |  |  |- 📜 LearningModulesContent.tsx
-|  |  |  |  |- 📜 FRQuestion.tsx
-|  |  |  |  |- 📜 MCQuestion.tsx
-|  |  |  |  |- 📜 Exercise.tsx
-|  |  |  |  |- 📜 ModulesSideBar.tsx
-|  |  |  |  |- 📜 ImageComponent.tsx
-|  |  |  |  |- 📜 ClassCard.tsx
-|  |  |  |- 📂 Dashboard:
-|  |  |  |  |- 📂 components:
-|  |  |  |  |  |- 📜 TrainBarChart.tsx
-|  |  |  |  |  |- 📜 TrainDoughnutChart.tsx
-|  |  |  |  |  |- 📜 TrainDataGrid.tsx
-|  |  |  |  |- 📂 redux:
-|  |  |  |  |  |- 📜 dashboardApi.ts
 |  |  |  |- 📂 OpenAi:
 |  |  |  |  |- 📜 openAiUtils.ts
 |  |  |  |- 📂 Feedback:
 |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |- 📜 feedbackApi.ts
 |  |  |  |- 📂 Train:
-|  |  |  |  |- 📂 components:
-|  |  |  |  |  |- 📜 CreateTrainspace.tsx
-|  |  |  |  |  |- 📜 TrainspaceLayout.tsx
-|  |  |  |  |  |- 📜 DatasetStepLayout.tsx
+|  |  |  |  |- 📂 types:
+|  |  |  |  |  |- 📜 trainTypes.ts
 |  |  |  |  |- 📂 features:
 |  |  |  |  |  |- 📂 Image:
-|  |  |  |  |  |  |- 📂 components:
-|  |  |  |  |  |  |  |- 📜 ImageFlow.tsx
-|  |  |  |  |  |  |  |- 📜 ImageDatasetStep.tsx
-|  |  |  |  |  |  |  |- 📜 ImageReviewStep.tsx
-|  |  |  |  |  |  |  |- 📜 ImageParametersStep.tsx
-|  |  |  |  |  |  |  |- 📜 ImageTrainspace.tsx
 |  |  |  |  |  |  |- 📂 types:
 |  |  |  |  |  |  |  |- 📜 imageTypes.ts
-|  |  |  |  |  |  |- 📂 constants:
-|  |  |  |  |  |  |  |- 📜 imageConstants.ts
 |  |  |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |  |  |- 📜 imageApi.ts
 |  |  |  |  |  |  |  |- 📜 imageActions.ts
+|  |  |  |  |  |  |- 📂 components:
+|  |  |  |  |  |  |  |- 📜 ImageParametersStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageFlow.tsx
+|  |  |  |  |  |  |  |- 📜 ImageDatasetStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageReviewStep.tsx
+|  |  |  |  |  |  |  |- 📜 ImageTrainspace.tsx
+|  |  |  |  |  |  |- 📂 constants:
+|  |  |  |  |  |  |  |- 📜 imageConstants.ts
 |  |  |  |  |  |  |- 📜 index.ts
 |  |  |  |  |  |- 📂 Tabular:
-|  |  |  |  |  |  |- 📂 components:
-|  |  |  |  |  |  |  |- 📜 TabularTrainspace.tsx
-|  |  |  |  |  |  |  |- 📜 TabularDatasetStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularParametersStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularReviewStep.tsx
-|  |  |  |  |  |  |  |- 📜 TabularFlow.tsx
 |  |  |  |  |  |  |- 📂 types:
 |  |  |  |  |  |  |  |- 📜 tabularTypes.ts
-|  |  |  |  |  |  |- 📂 constants:
-|  |  |  |  |  |  |  |- 📜 tabularConstants.ts
 |  |  |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |  |  |- 📜 tabularApi.ts
 |  |  |  |  |  |  |  |- 📜 tabularActions.ts
+|  |  |  |  |  |  |- 📂 components:
+|  |  |  |  |  |  |  |- 📜 TabularDatasetStep.tsx
+|  |  |  |  |  |  |  |- 📜 TabularReviewStep.tsx
+|  |  |  |  |  |  |  |- 📜 TabularParametersStep.tsx
+|  |  |  |  |  |  |  |- 📜 TabularTrainspace.tsx
+|  |  |  |  |  |  |  |- 📜 TabularFlow.tsx
+|  |  |  |  |  |  |- 📂 constants:
+|  |  |  |  |  |  |  |- 📜 tabularConstants.ts
 |  |  |  |  |  |  |- 📜 index.ts
-|  |  |  |  |- 📂 types:
-|  |  |  |  |  |- 📜 trainTypes.ts
-|  |  |  |  |- 📂 constants:
-|  |  |  |  |  |- 📜 trainConstants.ts
 |  |  |  |  |- 📂 redux:
 |  |  |  |  |  |- 📜 trainspaceApi.ts
 |  |  |  |  |  |- 📜 trainspaceSlice.ts
+|  |  |  |  |- 📂 components:
+|  |  |  |  |  |- 📜 CreateTrainspace.tsx
+|  |  |  |  |  |- 📜 DatasetStepLayout.tsx
+|  |  |  |  |  |- 📜 TrainspaceLayout.tsx
+|  |  |  |  |- 📂 constants:
+|  |  |  |  |  |- 📜 trainConstants.ts
+|  |  |  |- 📂 LearnMod:
+|  |  |  |  |- 📜 Exercise.tsx
+|  |  |  |  |- 📜 MCQuestion.tsx
+|  |  |  |  |- 📜 FRQuestion.tsx
+|  |  |  |  |- 📜 ClassCard.tsx
+|  |  |  |  |- 📜 LearningModulesContent.tsx
+|  |  |  |  |- 📜 ImageComponent.tsx
+|  |  |  |  |- 📜 ModulesSideBar.tsx
+|  |  |  |- 📂 Dashboard:
+|  |  |  |  |- 📂 redux:
+|  |  |  |  |  |- 📜 dashboardApi.ts
+|  |  |  |  |- 📂 components:
+|  |  |  |  |  |- 📜 TrainDoughnutChart.tsx
+|  |  |  |  |  |- 📜 TrainBarChart.tsx
+|  |  |  |  |  |- 📜 TrainDataGrid.tsx
 |  |  |- 📂 pages:
 |  |  |  |- 📂 train:
 |  |  |  |  |- 📜 [train_space_id].tsx
 |  |  |  |  |- 📜 index.tsx
-|  |  |  |- 📜 forgot.tsx
-|  |  |  |- 📜 LearnContent.tsx
-|  |  |  |- 📜 _document.tsx
-|  |  |  |- 📜 settings.tsx
-|  |  |  |- 📜 feedback.tsx
-|  |  |  |- 📜 wiki.tsx
-|  |  |  |- 📜 _app.tsx
 |  |  |  |- 📜 about.tsx
-|  |  |  |- 📜 login.tsx
 |  |  |  |- 📜 dashboard.tsx
+|  |  |  |- 📜 _document.tsx
 |  |  |  |- 📜 learn.tsx
+|  |  |  |- 📜 LearnContent.tsx
+|  |  |  |- 📜 wiki.tsx
+|  |  |  |- 📜 forgot.tsx
+|  |  |  |- 📜 settings.tsx
+|  |  |  |- 📜 _app.tsx
+|  |  |  |- 📜 feedback.tsx
+|  |  |  |- 📜 login.tsx
 |  |  |- 📂 backend_outputs:
-|  |  |  |- 📜 model.pt : Last model.pt output
 |  |  |  |- 📜 model.pkl
+|  |  |  |- 📜 model.pt : Last model.pt output
 |  |  |  |- 📜 my_deep_learning_model.onnx : Last ONNX file output
 |  |  |- 📂 common:
+|  |  |  |- 📂 redux:
+|  |  |  |  |- 📜 store.ts
+|  |  |  |  |- 📜 train.ts
+|  |  |  |  |- 📜 backendApi.ts
+|  |  |  |  |- 📜 hooks.ts
+|  |  |  |  |- 📜 userLogin.ts
 |  |  |  |- 📂 components:
-|  |  |  |  |- 📜 NavBarMain.tsx
-|  |  |  |  |- 📜 ClientOnlyPortal.tsx
-|  |  |  |  |- 📜 HtmlTooltip.tsx
-|  |  |  |  |- 📜 Spacer.tsx
 |  |  |  |  |- 📜 EmailInput.tsx
-|  |  |  |  |- 📜 Footer.tsx
-|  |  |  |  |- 📜 DlpTooltip.tsx
 |  |  |  |  |- 📜 TitleText.tsx
+|  |  |  |  |- 📜 NavBarMain.tsx
+|  |  |  |  |- 📜 Spacer.tsx
+|  |  |  |  |- 📜 DlpTooltip.tsx
+|  |  |  |  |- 📜 Footer.tsx
+|  |  |  |  |- 📜 HtmlTooltip.tsx
+|  |  |  |  |- 📜 ClientOnlyPortal.tsx
+|  |  |  |- 📂 utils:
+|  |  |  |  |- 📜 dateFormat.ts
+|  |  |  |  |- 📜 dndHelpers.ts
+|  |  |  |  |- 📜 firebase.ts
 |  |  |  |- 📂 styles:
 |  |  |  |  |- 📜 globals.css
 |  |  |  |  |- 📜 Home.module.css
-|  |  |  |- 📂 utils:
-|  |  |  |  |- 📜 dndHelpers.ts
-|  |  |  |  |- 📜 dateFormat.ts
-|  |  |  |  |- 📜 firebase.ts
-|  |  |  |- 📂 redux:
-|  |  |  |  |- 📜 train.ts
-|  |  |  |  |- 📜 userLogin.ts
-|  |  |  |  |- 📜 store.ts
-|  |  |  |  |- 📜 hooks.ts
-|  |  |  |  |- 📜 backendApi.ts
-|  |  |- 📜 next-env.d.ts
-|  |  |- 📜 iris.csv : Sample CSV data
-|  |  |- 📜 constants.ts
 |  |  |- 📜 GlobalStyle.ts
-|  |- 📜 next-env.d.ts
-|  |- 📜 package.json
-|  |- 📜 next.config.js
-|  |- 📜 .eslintignore
+|  |  |- 📜 constants.ts
+|  |  |- 📜 iris.csv : Sample CSV data
+|  |  |- 📜 next-env.d.ts
 |  |- 📜 .eslintrc.json
-|  |- 📜 tsconfig.json
-|  |- 📜 pnpm-lock.yaml
-|  |- 📜 jest.config.js
 |  |- 📜 yarn.lock
+|  |- 📜 package.json
+|  |- 📜 .eslintignore
+|  |- 📜 next.config.js
+|  |- 📜 pnpm-lock.yaml
+|  |- 📜 tsconfig.json
+|  |- 📜 next-env.d.ts
+|  |- 📜 jest.config.js
 ```
 

--- a/.github/workflows/training-container.yml
+++ b/.github/workflows/training-container.yml
@@ -32,13 +32,13 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_REGION: "us-west-2"                    # set this to your preferred AWS region, e.g. us-west-1
-  ECR_REPOSITORY: "dlp-training"           # set this to your Amazon ECR repository name
-  ECS_SERVICE: "dlp-training-service"                 # set this to your Amazon ECS service name
-  ECS_CLUSTER: "deep-learning-playground-kernels"                 # set this to your Amazon ECS cluster name
+  AWS_REGION: "us-east-1"                    # set this to your preferred AWS region, e.g. us-west-1
+  ECR_REPOSITORY: "dlp-backend-image"           # set this to your Amazon ECR repository name
+  ECS_SERVICE: "BackendService"                 # set this to your Amazon ECS service name
+  ECS_CLUSTER: "BackendCluster"                 # set this to your Amazon ECS cluster name
   ECS_TASK_DEFINITION: ".aws/training-task-definition.json" # set this to the path to your Amazon ECS task definition
                                                # file, e.g. .aws/task-definition.json
-  CONTAINER_NAME: "dlp-training-container"           # set this to the name of the container in the
+  CONTAINER_NAME: "backend"           # set this to the name of the container in the
                                                # containerDefinitions section of your task definition
 
 permissions:
@@ -77,9 +77,9 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -f TrainingContainer.Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg TARGETARCH="x86" --build-arg AWS_REGION=${{ env.AWS_REGION }} --build-arg AWS_DEPLOY_ACCESS_KEY_ID=${{ secrets.AWS_DEPLOY_ACCESS_KEY_ID }} --build-arg AWS_DEPLOY_SECRET_ACCESS_KEY=${{ secrets.AWS_DEPLOY_SECRET_ACCESS_KEY }} .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . -f training/Dockerfile.prod
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def

--- a/training/Dockerfile
+++ b/training/Dockerfile
@@ -1,7 +1,5 @@
 # pull base image
 FROM condaforge/miniforge3
-ARG ENV=dev
-ENV NODE_ENV=${ENV}
 
 WORKDIR /usr/src/training
 

--- a/training/Dockerfile.prod
+++ b/training/Dockerfile.prod
@@ -12,7 +12,7 @@ RUN mamba create --name dlp -y
 
 COPY environment.yml pyproject.toml poetry.lock ./
 RUN mamba run --live-stream -n dlp mamba env update --file environment.yml --prune
-RUN mamba run --live-stream -n dlp poetry install
+RUN mamba run --live-stream -n dlp poetry install --without dev
 
 # create directory for the app user
 RUN mkdir -p /home/app
@@ -35,4 +35,4 @@ RUN chown -R app:app $APP_HOME
 # change to the app user
 USER app
 
-CMD mamba run --live-stream -n dlp poetry run python manage.py runserver 0.0.0.0:8000
+CMD mamba run --live-stream -n dlp gunicorn training.wsgi:application --bind 0.0.0.0:8000

--- a/training/Dockerfile.prod
+++ b/training/Dockerfile.prod
@@ -1,7 +1,5 @@
 # pull base image
 FROM condaforge/miniforge3
-ARG ENV=dev
-ENV NODE_ENV=${ENV}
 
 WORKDIR /usr/src/training
 

--- a/training/docker-compose.prod.yml
+++ b/training/docker-compose.prod.yml
@@ -3,10 +3,7 @@ version: '3.8'
 services:
   web:
     build:
-      context: .
-      args:
-        ENV: prod
-    command: mamba run --live-stream -n dlp gunicorn training.wsgi:application --bind 0.0.0.0:8000
+      dockerfile: Dockerfile.prod
     volumes:
       - ./:/usr/src/training/
       - $HOME/.aws/credentials:/home/app/.aws/credentials:ro

--- a/training/docker-compose.yml
+++ b/training/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.8'
 services:
   web:
     build: .
-    command: mamba run --live-stream -n dlp poetry run python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./:/usr/src/training/
       - $HOME/.aws/credentials:/home/app/.aws/credentials:ro


### PR DESCRIPTION
# Deploy training backend to ecs

Github Issue Number Here: #1075 
**What user problem are we solving?**
We want to automatically build the training backend docker image, push to ecr, and update the ecs service container

**What solution does this PR provide?**
After creating an ecr repository, ecs cluster, and ecs task definition, we should be able to run a github action that automatically deploys to our g4dn.xlarge instance on the ecs cluster

**Testing Methodology**
Ran docker compose on dev and prod docker compose files, made sure they still work with the frontend. Need to test github action after pushing

**Any other considerations**