### PR TITLE
Updated AppStack so create trainspace shows up in the output

### DIFF
--- a/serverless/stacks/AppStack.ts
+++ b/serverless/stacks/AppStack.ts
@@ -90,6 +90,8 @@ export function AppStack({ stack }: StackContext) {
     GetUserDatasetColumnsFunctionName:
       api.getFunction("GET /datasets/user/{type}/{filename}/columns")
         ?.functionName ?? "",
+    CreateTrainspaceFunctionName:
+        api.getFunction("POST /trainspace/create")?.functionName ?? "",
     PutTabularTrainspaceFunctionName:
         api.getFunction("POST /trainspace/tabular")?.functionName ?? "",
     PutImageTrainspaceFunctionName:


### PR DESCRIPTION
N/A

Github Issue Number Here: N/A
The new create trainspace function didn't show up in the output when running server less:

Solution: Added the new create trainspace function to the output so that it shows up now in the terminal:

Testing Methodology

How did you test your changes and verify that existing functionality is not broken
There were no changes to any functionality other than appearance. This is what it looked like before:
![image](https://github.com/DSGT-DLP/Deep-Learning-Playground/assets/116283570/fd9cc259-582b-4974-a965-efe5089bef52)

This is what it looks like now, you can see that CreateTrainspaceFunctionName now exists:
<img width="814" alt="image" src="https://github.com/DSGT-DLP/Deep-Learning-Playground/assets/116283570/2bdaf3d1-23fd-488a-ac08-833bf31895ba">
