### PR TITLE
Remove aws_write from pre commits,

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,6 @@ repos:
       # - id: poetry-lock
       #   entry: sh -c 'cd backend && poetry lock'
         
-      - id: poetry-check
-        entry: sh -c 'cd aws_write && poetry check'
-        
-      # - id: poetry-lock
-      #   entry: sh -c 'cd aws_write && poetry lock'
-        
   - repo: https://github.com/gitguardian/ggshield
     rev: v1.14.2
     hooks:


### PR DESCRIPTION
# Remove aws_write from pre commits

**What user problem are we solving?**
Pre commits fail because aws_write folder was deleted

**What solution does this PR provide?**
Remove aws_write from pre commits

**Testing Methodology**
Pre commit passes now